### PR TITLE
JBIDE-12955 fix relative path

### DIFF
--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>cdi</artifactId>

--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -4,7 +4,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>jsf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>javaee.all</artifactId>

--- a/seam/pom.xml
+++ b/seam/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>seam</artifactId>

--- a/struts/pom.xml
+++ b/struts/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>struts</artifactId>


### PR DESCRIPTION
I suggest we don't use the root of "uber" components as the parent since components like central would overlap in naming and maven in central is not really a child of central. WDYT ?
