### PR TITLE
fix pom hierarchy for javaee component

### DIFF
--- a/all-tests/pom.xml
+++ b/all-tests/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>javaee.all</artifactId>
+		<artifactId>javaee</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>javaee.all.tests</artifactId>
+	<groupId>org.jboss.tools.javaee</groupId>
+	<artifactId>all-tests</artifactId>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -3,9 +3,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>javaee</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>cdi</artifactId>

--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -2,9 +2,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>javaee</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>jsf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
-	<artifactId>javaee.all</artifactId>
+	<artifactId>javaee</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>

--- a/seam/pom.xml
+++ b/seam/pom.xml
@@ -5,9 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>javaee</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>seam</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>javaee.all</artifactId>
+		<artifactId>javaee</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>javaee.site</artifactId>
+	<groupId>org.jboss.tools.javaee</groupId>
+	<artifactId>site</artifactId>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>

--- a/struts/pom.xml
+++ b/struts/pom.xml
@@ -3,9 +3,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>javaee</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>struts</artifactId>


### PR DESCRIPTION
subcomponents reference local parent pom as parent
"all" removed from root component artifactId
