### PR TITLE
https://issues.jboss.org/browse/JBIDE-13152

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/views/AbstractSeamContentProvider.java
+++ b/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/views/AbstractSeamContentProvider.java
@@ -254,7 +254,11 @@ public abstract class AbstractSeamContentProvider implements ITreeContentProvide
 		public void resourceChanged(IResourceChangeEvent event) {
 			try {
 				if (event.getDelta() == null) {
-					refresh(null);
+					if(event.getType() == IResourceChangeEvent.PRE_DELETE
+						|| event.getType() == IResourceChangeEvent.PRE_CLOSE) {
+						handlePreDelete(event.getResource());
+					}
+//					refresh(null);
 				} else {
 					event.getDelta().accept(visitor);
 				}
@@ -264,6 +268,16 @@ public abstract class AbstractSeamContentProvider implements ITreeContentProvide
 		}
 		
 	}
+
+	protected void handlePreDelete(IResource resource) {
+	}
+
+	protected void handleProjectAdded(IProject project) {
+	}
+	
+	protected void handleProjectInfoChanged(IProject project) {
+		refresh(project);
+	}
 	
 	class ResourceDeltaVisitor implements IResourceDeltaVisitor {
 
@@ -272,14 +286,20 @@ public abstract class AbstractSeamContentProvider implements ITreeContentProvide
 			IResource r = delta.getResource();
 			if(kind == IResourceDelta.ADDED || kind == IResourceDelta.REMOVED) {
 				if(r instanceof IProject) {
-					refresh(null);
+					if(kind == IResourceDelta.ADDED) {
+						handleProjectAdded((IProject)r);
+					} else {
+						//Do nothing, PRE_DELETE event already was sent.
+					}
+//					refresh(null);
 				}
 			} else if(kind == IResourceDelta.CHANGED) {
 				IResourceDelta[] cs = delta.getAffectedChildren();
 				if(cs != null) for (int i = 0; i < cs.length; i++) {
 					IResource c = cs[i].getResource();
 					if(c instanceof IFile && c.getName().endsWith(".project")) { //$NON-NLS-1$
-						refresh(null);
+						handleProjectInfoChanged(c.getProject());
+//						refresh(null);
 					}
 				}
 			}

--- a/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/views/RootContentProvider.java
+++ b/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/views/RootContentProvider.java
@@ -16,7 +16,10 @@ import java.util.List;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.widgets.Display;
 import org.jboss.tools.seam.core.ISeamProject;
 import org.jboss.tools.seam.core.SeamCorePlugin;
 
@@ -79,6 +82,32 @@ public class RootContentProvider extends AbstractSeamContentProvider {
 		}
 	}
 
+	protected void handlePreDelete(IResource resource) {
+		if(viewer == null || viewer.getControl() == null || viewer.getControl().isDisposed()) return;
+		if(resource instanceof IProject) {
+			final IProject p = (IProject)resource;
+			if(viewer instanceof TreeViewer) {
+				if(Display.getCurrent() != null) {
+					((TreeViewer)viewer).remove(p);
+				} else {
+					Display.getDefault().asyncExec(new Runnable() {
+						public void run() {
+							((TreeViewer)viewer).remove(p);
+						}
+					});					
+				}
+			}
+		}
+	}
+	
+	protected void handleProjectAdded(IProject project) {
+		refresh(null);
+	}
+
+	protected void handleProjectInfoChanged(IProject project) {
+		refresh(null);
+	}
+	
 	protected Object getTreeObject(Object source) {
 		if(source instanceof ISeamProject) {
 			return ((ISeamProject)source).getProject();


### PR DESCRIPTION
Do not call refresh of the entire tree of Project Explorer
when a project added/removed; and tree of Seam Components
when a project removed.
