### PR TITLE
JBIDE-13538 "Interceptors already contains class" error

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/BeansXMLAccess.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/BeansXMLAccess.java
@@ -1,0 +1,154 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdi.ui.wizard;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ui.wizards.NewTypeWizardPage;
+import org.eclipse.swt.widgets.Composite;
+import org.jboss.tools.cdi.ui.CDIUIPlugin;
+import org.jboss.tools.cdi.xml.beans.model.CDIBeansConstants;
+import org.jboss.tools.common.meta.action.XActionInvoker;
+import org.jboss.tools.common.meta.action.impl.handlers.DefaultCreateHandler;
+import org.jboss.tools.common.model.XModelFactory;
+import org.jboss.tools.common.model.XModelObject;
+import org.jboss.tools.common.model.filesystems.impl.FileAnyImpl;
+import org.jboss.tools.common.model.util.EclipseResourceUtil;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class BeansXMLAccess {
+	String folderName;
+	String entity;
+	String attribute;
+	protected NewTypeWizardPage page;
+	protected CheckBoxEditorWrapper check = null;
+	protected boolean isEnabled = true;
+
+	public BeansXMLAccess(NewTypeWizardPage page, String folderName, String entity, String attribute) {
+		this.page = page;
+		this.folderName = folderName;
+		this.entity = entity;
+		this.attribute = attribute;
+	}
+
+	public void create(Composite composite) {
+		create(composite, true);
+	}
+
+	public void create(Composite composite, boolean initValue) {
+		String label = "Register in beans.xml";
+		check = NewBeanWizardPage.createCheckBoxField(composite, "register", label, initValue);
+	}
+
+	public boolean isSelected() {
+		if(check != null) {
+			return check.composite.getValue() == Boolean.TRUE
+					&& check.checkBox.isEnabled();
+		}
+		return false;
+	}
+
+	public void setEnabled(boolean b) {
+		isEnabled = b;
+		validate();
+	}
+
+	public void validate() {
+		if(check == null) {
+			return;
+		}
+		IPackageFragmentRoot p = page.getPackageFragmentRoot();
+		if(p != null && p.getResource().exists()) {
+			String typeName = page.getPackageText() + "." + page.getTypeName();
+			IProject project = p.getResource().getProject();
+			boolean b = isRegisteredInBeansXML(project, typeName);
+			check.composite.setEnabled(!b && isEnabled);
+		} else {
+			check.composite.setEnabled(isEnabled);
+		}
+	}
+
+	public void registerInBeansXML() {
+		IProject project = page.getCreatedType().getResource().getProject();
+		IPath path = NewBeansXMLCreationWizard.getContainerForBeansXML(project);
+		if(path != null) {
+			path = path.append("beans.xml").removeFirstSegments(1); //$NON-NLS-1$
+			IFile beansxml = project.getFile(path);
+			if(!beansxml.exists()) {
+				try {
+					createBeansXML(beansxml);
+				} catch (CoreException e) {
+					CDIUIPlugin.getDefault().logError(e);
+				}
+			}
+			if(beansxml.exists()) {
+				XModelObject o = EclipseResourceUtil.createObjectForResource(beansxml);
+				if(o != null) {
+					XModelObject as = o.getChildByPath(folderName);
+					XModelObject c = as.getModel().createModelObject(entity, new Properties());
+					c.setAttributeValue(attribute, page.getCreatedType().getFullyQualifiedName());
+					//Check that 'typeName' is already registered in 'folderName'.
+					if(as.getChildByPath(c.getPathPart()) == null) {
+						try {
+							DefaultCreateHandler.addCreatedObject(as, c, 0);
+							XActionInvoker.invoke("SaveActions.Save", o, new Properties()); //$NON-NLS-1$
+						} catch (CoreException e) {
+							CDIUIPlugin.getDefault().logError(e);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	public boolean isRegisteredInBeansXML(IProject project, String typeName) {
+		IPath path = NewBeansXMLCreationWizard.getContainerForBeansXML(project);
+		if(path != null) {
+			path = path.append("beans.xml").removeFirstSegments(1); //$NON-NLS-1$
+			IFile beansxml = project.getFile(path);
+			if(beansxml.exists()) {
+				XModelObject o = EclipseResourceUtil.createObjectForResource(beansxml);
+				if(o != null) {
+					return  o.getChildByPath(folderName + "/" + typeName) != null;
+				}
+			}
+		}			
+		return false;
+	}
+
+	public static void createBeansXML(IFile f) throws CoreException {
+		if(f.exists()) return;
+		IFolder folder = (IFolder)f.getParent();
+		if(!folder.exists()) {
+			folder.create(true, true, new NullProgressMonitor());
+		}
+		f.create(getBeansXMLInitialContents(), true, new NullProgressMonitor());
+	}
+
+	public static InputStream getBeansXMLInitialContents() {
+		FileAnyImpl file = (FileAnyImpl)XModelFactory.getDefaultInstance().createModelObject(CDIBeansConstants.ENT_CDI_BEANS, new Properties());
+		return new ByteArrayInputStream(file.getAsText().getBytes());
+	}
+
+}

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/CheckBoxEditorWrapper.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/CheckBoxEditorWrapper.java
@@ -1,0 +1,24 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdi.ui.wizard;
+
+import org.jboss.tools.common.ui.widget.editor.CheckBoxFieldEditor;
+import org.jboss.tools.common.ui.widget.editor.IFieldEditor;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+class CheckBoxEditorWrapper {
+	protected IFieldEditor composite = null;
+	protected CheckBoxFieldEditor checkBox = null;
+}

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewBeanCreationWizard.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewBeanCreationWizard.java
@@ -73,54 +73,9 @@ public class NewBeanCreationWizard extends NewCDIElementWizard {
 	public boolean performFinish() {
 		boolean res = super.performFinish();
 		if(res && ((NewBeanWizardPage)fPage).isToBeRegisteredInBeansXML()) {
-			IProject project = fPage.getCreatedType().getResource().getProject();
-			registerInBeansXML(project, fPage.getCreatedType().getFullyQualifiedName(), "Alternatives", CDIBeansConstants.ENT_CDI_CLASS, CDIBeansConstants.ATTR_CLASS); //$NON-NLS-1$
+			((NewBeanWizardPage)fPage).registerInBeansXML.registerInBeansXML();
 		}
 		return res;
 	}
-
-	public static void registerInBeansXML(IProject project, String typeName, String folderName, String entity, String attribute) {
-		IPath path = NewBeansXMLCreationWizard.getContainerForBeansXML(project);
-		if(path != null) {
-			path = path.append("beans.xml").removeFirstSegments(1); //$NON-NLS-1$
-			IFile beansxml = project.getFile(path);
-			if(!beansxml.exists()) {
-				try {
-					createBeansXML(beansxml);
-				} catch (CoreException e) {
-					CDIUIPlugin.getDefault().logError(e);
-				}
-			}
-			if(beansxml.exists()) {
-				XModelObject o = EclipseResourceUtil.createObjectForResource(beansxml);
-				if(o != null) {
-					XModelObject as = o.getChildByPath(folderName);
-					XModelObject c = as.getModel().createModelObject(entity, new Properties());
-					c.setAttributeValue(attribute, typeName);
-					try {
-						DefaultCreateHandler.addCreatedObject(as, c, 0);
-						XActionInvoker.invoke("SaveActions.Save", o, new Properties()); //$NON-NLS-1$
-					} catch (CoreException e) {
-						CDIUIPlugin.getDefault().logError(e);
-					}
-				}
-			}
-		}
-	}
-
-	public static void createBeansXML(IFile f) throws CoreException {
-		if(f.exists()) return;
-		IFolder folder = (IFolder)f.getParent();
-		if(!folder.exists()) {
-			folder.create(true, true, new NullProgressMonitor());
-		}
-		f.create(getBeansXMLInitialContents(), true, new NullProgressMonitor());
-	}
-
-	public static InputStream getBeansXMLInitialContents() {
-		FileAnyImpl file = (FileAnyImpl)XModelFactory.getDefaultInstance().createModelObject(CDIBeansConstants.ENT_CDI_BEANS, new Properties());
-		return new ByteArrayInputStream(file.getAsText().getBytes());
-	}
-
 
 }

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewBeanWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewBeanWizardPage.java
@@ -54,6 +54,7 @@ import org.jboss.tools.cdi.core.ICDIProject;
 import org.jboss.tools.cdi.core.IQualifier;
 import org.jboss.tools.cdi.core.IScope;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
+import org.jboss.tools.cdi.xml.beans.model.CDIBeansConstants;
 import org.jboss.tools.common.ui.widget.editor.CheckBoxFieldEditor;
 import org.jboss.tools.common.ui.widget.editor.CompositeEditor;
 import org.jboss.tools.common.ui.widget.editor.IFieldEditor;
@@ -71,7 +72,7 @@ import org.jboss.tools.common.ui.widget.editor.TextFieldEditor;
 public class NewBeanWizardPage extends NewClassWizardPage {
 	protected CheckBoxEditorWrapper alternative = null;
 	protected boolean mayBeRegisteredInBeansXML = true;
-	protected CheckBoxEditorWrapper registerInBeansXML = null;
+	protected BeansXMLAccess registerInBeansXML = new BeansXMLAccess(this, "Alternatives", CDIBeansConstants.ENT_CDI_CLASS, CDIBeansConstants.ATTR_CLASS);
 
 	protected CheckBoxEditorWrapper isNamed;
 	protected BeanNameEditorWrapper beanName;
@@ -357,11 +358,6 @@ public class NewBeanWizardPage extends NewClassWizardPage {
 		beanName.composite.setValue(name);
 	}
 
-	protected static class CheckBoxEditorWrapper {
-		protected IFieldEditor composite = null;
-		protected CheckBoxFieldEditor checkBox = null;
-	}
-
 	protected static class BeanNameEditorWrapper {
 		protected IFieldEditor composite = null;
 		protected TextFieldEditor text = null;
@@ -384,18 +380,15 @@ public class NewBeanWizardPage extends NewClassWizardPage {
 			alternative.checkBox.addPropertyChangeListener(new PropertyChangeListener() {
 				public void propertyChange(PropertyChangeEvent evt) {
 					boolean isAlternative = "true".equals(alternative.checkBox.getValueAsString());
-					if(registerInBeansXML != null) {
-						registerInBeansXML.composite.setEnabled(isAlternative);
-					}
+					registerInBeansXML.setEnabled(isAlternative);
 				}});
 		}
 	}
 
 	protected void createRegisterInBeansXML(Composite composite) {
 		if(!mayBeRegisteredInBeansXML) return;
-		String label = "Register in beans.xml";
-		registerInBeansXML = createCheckBoxField(composite, "register", label, isAlternativeInitialValue);
-		registerInBeansXML.composite.setEnabled(isAlternativeInitialValue);
+		registerInBeansXML.create(composite, isAlternativeInitialValue);
+		registerInBeansXML.setEnabled(isAlternativeInitialValue);
 	}
 
 	protected static CheckBoxEditorWrapper createCheckBoxField(Composite composite, String name, String label, boolean defaultValue) {
@@ -503,7 +496,7 @@ public class NewBeanWizardPage extends NewClassWizardPage {
 
 	public boolean isToBeRegisteredInBeansXML() {
 		if(registerInBeansXML != null && alternative != null ) {
-			return alternative.composite.getValue() == Boolean.TRUE && registerInBeansXML.composite.getValue() == Boolean.TRUE;
+			return alternative.composite.getValue() == Boolean.TRUE && registerInBeansXML.isSelected();
 		}
 		return false;
 	}
@@ -520,4 +513,15 @@ public class NewBeanWizardPage extends NewClassWizardPage {
 		}
 	}
 
+	protected IStatus packageChanged() {
+		IStatus result = super.packageChanged();
+		registerInBeansXML.validate();
+		return result;
+	}
+
+	protected IStatus typeNameChanged() {
+		IStatus result = super.typeNameChanged();
+		registerInBeansXML.validate();
+		return result;
+	}
 }

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewCDIAnnotationWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewCDIAnnotationWizardPage.java
@@ -140,11 +140,6 @@ public abstract class NewCDIAnnotationWizardPage extends NewAnnotationWizardPage
 
 	protected abstract void createCustomFields(Composite composite);
 
-	protected static class CheckBoxEditorWrapper {
-		protected IFieldEditor composite = null;
-		protected CheckBoxFieldEditor checkBox = null;
-	}
-
 	protected CheckBoxEditorWrapper createCheckBoxField(Composite composite, String name, String label, boolean defaultValue) {
 		CheckBoxEditorWrapper wrapper = new CheckBoxEditorWrapper();
 		wrapper.checkBox = new CheckBoxFieldEditor(name,label,Boolean.valueOf(defaultValue));

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewDecoratorCreationWizard.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewDecoratorCreationWizard.java
@@ -52,8 +52,7 @@ public class NewDecoratorCreationWizard extends NewCDIElementWizard {
 	public boolean performFinish() {
 		boolean res = super.performFinish();
 		if(res && ((NewDecoratorWizardPage)fPage).isToBeRegisteredInBeansXML()) {
-			IProject project = fPage.getCreatedType().getResource().getProject();
-			NewBeanCreationWizard.registerInBeansXML(project, fPage.getCreatedType().getFullyQualifiedName(), "Decorators", "CDIClass", "class");
+			((NewDecoratorWizardPage)fPage).registerInBeansXML.registerInBeansXML();
 		}
 		return res;
 	}

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewDecoratorWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewDecoratorWizardPage.java
@@ -51,7 +51,7 @@ import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICorePlugin;
 import org.jboss.tools.cdi.core.CDIImages;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
-import org.jboss.tools.cdi.ui.wizard.NewBeanWizardPage.CheckBoxEditorWrapper;
+import org.jboss.tools.cdi.xml.beans.model.CDIBeansConstants;
 import org.jboss.tools.common.java.generation.JavaBeanGenerator;
 import org.jboss.tools.common.ui.widget.editor.CompositeEditor;
 import org.jboss.tools.common.ui.widget.editor.IFieldEditor;
@@ -72,7 +72,7 @@ public class NewDecoratorWizardPage extends NewClassWizardPage {
 	protected StatusInfo fieldNameStatus = new StatusInfo();
 
 	protected boolean mayBeRegisteredInBeansXML = true;
-	protected CheckBoxEditorWrapper registerInBeansXML = null;
+	protected BeansXMLAccess registerInBeansXML = new BeansXMLAccess(this, "Decorators", CDIBeansConstants.ENT_CDI_CLASS, CDIBeansConstants.ATTR_CLASS);
 
 	public NewDecoratorWizardPage() {
 		setTitle(CDIUIMessages.NEW_DECORATOR_WIZARD_PAGE_NAME);
@@ -288,8 +288,7 @@ public class NewDecoratorWizardPage extends NewClassWizardPage {
 
 	protected void createRegisterInBeansXML(Composite composite) {
 		if(!mayBeRegisteredInBeansXML) return;
-		String label = "Register in beans.xml";
-		registerInBeansXML = NewBeanWizardPage.createCheckBoxField(composite, "register", label, true);
+		registerInBeansXML.create(composite);
 	}
 
 	protected IField createDelegateField(IType type, ImportsManager imports,
@@ -436,10 +435,7 @@ public class NewDecoratorWizardPage extends NewClassWizardPage {
 	}
 
 	public boolean isToBeRegisteredInBeansXML() {
-		if(registerInBeansXML != null) {
-			return registerInBeansXML.composite.getValue() == Boolean.TRUE;
-		}
-		return false;
+		return registerInBeansXML.isSelected();
 	}
 
 	@Override
@@ -452,5 +448,20 @@ public class NewDecoratorWizardPage extends NewClassWizardPage {
 
 	protected String getSuperInterfacesLabel() {
 		return CDIUIMessages.NEW_DECORATOR_WIZARD_INTERFACES_LABEL;
+	}
+
+	protected IStatus packageChanged() {
+		IStatus result = super.packageChanged();
+		if(result != null && result.isOK()) {
+			interceptorBindingsProvider.setPackageFragment(getPackageFragment());
+		}
+		registerInBeansXML.validate();
+		return result;
+	}
+
+	protected IStatus typeNameChanged() {
+		IStatus result = super.typeNameChanged();
+		registerInBeansXML.validate();
+		return result;
 	}
 }

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewInterceptorCreationWizard.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewInterceptorCreationWizard.java
@@ -11,7 +11,6 @@
 
 package org.jboss.tools.cdi.ui.wizard;
 
-import org.eclipse.core.resources.IProject;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
 
 /**
@@ -51,8 +50,7 @@ public class NewInterceptorCreationWizard extends NewCDIElementWizard {
 	public boolean performFinish() {
 		boolean res = super.performFinish();
 		if(res && ((NewInterceptorWizardPage)fPage).isToBeRegisteredInBeansXML()) {
-			IProject project = fPage.getCreatedType().getResource().getProject();
-			NewBeanCreationWizard.registerInBeansXML(project, fPage.getCreatedType().getFullyQualifiedName(), "Interceptors", "CDIClass", "class");
+			((NewInterceptorWizardPage)fPage).registerInBeansXML.registerInBeansXML();
 		}
 		return res;
 	}

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewInterceptorWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewInterceptorWizardPage.java
@@ -16,6 +16,7 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -24,6 +25,7 @@ import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
@@ -50,7 +52,7 @@ import org.jboss.tools.cdi.core.CDIImages;
 import org.jboss.tools.cdi.core.ICDIAnnotation;
 import org.jboss.tools.cdi.core.ICDIProject;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
-import org.jboss.tools.cdi.ui.wizard.NewBeanWizardPage.CheckBoxEditorWrapper;
+import org.jboss.tools.cdi.xml.beans.model.CDIBeansConstants;
 import org.jboss.tools.common.java.generation.JavaBeanGenerator;
 import org.jboss.tools.common.ui.widget.editor.CompositeEditor;
 import org.jboss.tools.common.ui.widget.editor.IFieldEditor;
@@ -72,7 +74,7 @@ public class NewInterceptorWizardPage extends NewClassWizardPage {
 	protected StatusInfo interceptorBindingsStatus = new StatusInfo();
 
 	protected boolean mayBeRegisteredInBeansXML = true;
-	protected CheckBoxEditorWrapper registerInBeansXML = null;
+	protected BeansXMLAccess registerInBeansXML = new BeansXMLAccess(this, "Interceptors", CDIBeansConstants.ENT_CDI_CLASS, CDIBeansConstants.ATTR_CLASS);
 
 	public void setMayBeRegisteredInBeansXML(boolean b) {
 		mayBeRegisteredInBeansXML = b;
@@ -215,8 +217,7 @@ public class NewInterceptorWizardPage extends NewClassWizardPage {
 
 	protected void createRegisterInBeansXML(Composite composite) {
 		if(!mayBeRegisteredInBeansXML) return;
-		String label = "Register in beans.xml";
-		registerInBeansXML = NewBeanWizardPage.createCheckBoxField(composite, "register", label, true);
+		registerInBeansXML.create(composite);
 	}
 
 	void setInterceptorBindings(IPackageFragmentRoot root) {
@@ -325,14 +326,18 @@ public class NewInterceptorWizardPage extends NewClassWizardPage {
 		if(result != null && result.isOK()) {
 			interceptorBindingsProvider.setPackageFragment(getPackageFragment());
 		}
+		registerInBeansXML.validate();
 		return result;
 	}
 
 	public boolean isToBeRegisteredInBeansXML() {
-		if(registerInBeansXML != null) {
-			return registerInBeansXML.composite.getValue() == Boolean.TRUE;
-		}
-		return false;
+		return registerInBeansXML.isSelected();
+	}
+
+	protected IStatus typeNameChanged() {
+		IStatus result = super.typeNameChanged();
+		registerInBeansXML.validate();
+		return result;
 	}
 
 }

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewScopeWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewScopeWizardPage.java
@@ -16,7 +16,6 @@ import java.beans.PropertyChangeListener;
 import org.eclipse.swt.widgets.Composite;
 import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
-import org.jboss.tools.cdi.ui.wizard.NewCDIAnnotationWizardPage.CheckBoxEditorWrapper;
 
 /**
  * 

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewStereotypeCreationWizard.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewStereotypeCreationWizard.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.ui.wizard;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.ui.wizards.NewAnnotationWizardPage;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
 
@@ -40,8 +39,7 @@ public class NewStereotypeCreationWizard extends NewCDIAnnotationCreationWizard 
 	public boolean performFinish() {
 		boolean res = super.performFinish();
 		if(res && ((NewStereotypeWizardPage)fPage).isToBeRegisteredInBeansXML()) {
-			IProject project = fPage.getCreatedType().getResource().getProject();
-			NewBeanCreationWizard.registerInBeansXML(project, fPage.getCreatedType().getFullyQualifiedName(), "Alternatives", "CDIStereotype", "stereotype");
+			((NewStereotypeWizardPage)fPage).registerInBeansXML.registerInBeansXML();
 		}
 		return res;
 	}

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewStereotypeWizardPage.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/wizard/NewStereotypeWizardPage.java
@@ -47,7 +47,7 @@ import org.jboss.tools.common.ui.widget.editor.ListFieldEditor;
 public class NewStereotypeWizardPage extends NewCDIAnnotationWizardPage {
 	protected CheckBoxEditorWrapper alternative = null;
 	protected boolean mayBeRegisteredInBeansXML = true;
-	protected CheckBoxEditorWrapper registerInBeansXML = null;
+	protected BeansXMLAccess registerInBeansXML = new BeansXMLAccess(this,"Alternatives", "CDIStereotype", "stereotype");
 
 	protected CheckBoxEditorWrapper named = null;
 	protected ITaggedFieldEditor scope = null;
@@ -153,18 +153,15 @@ public class NewStereotypeWizardPage extends NewCDIAnnotationWizardPage {
 			alternative.checkBox.addPropertyChangeListener(new PropertyChangeListener() {
 				public void propertyChange(PropertyChangeEvent evt) {
 					boolean isAlternative = "true".equals(alternative.checkBox.getValueAsString());
-					if(registerInBeansXML != null) {
-						registerInBeansXML.composite.setEnabled(isAlternative);
-					}
+					registerInBeansXML.setEnabled(isAlternative);
 				}});
 		}
 	}
 
 	protected void createRegisterInBeansXML(Composite composite) {
 		if(!mayBeRegisteredInBeansXML) return;
-		String label = "Register in beans.xml";
-		registerInBeansXML = createCheckBoxField(composite, "register", label, isAlternativeInitialValue);
-		registerInBeansXML.composite.setEnabled(isAlternativeInitialValue);
+		registerInBeansXML.create(composite, isAlternativeInitialValue);
+		registerInBeansXML.setEnabled(isAlternativeInitialValue);
 	}
 
 	protected void createNamedField(Composite composite) {
@@ -359,15 +356,26 @@ public class NewStereotypeWizardPage extends NewCDIAnnotationWizardPage {
 
 	public void setToBeRegisteredInBeansXML(boolean value) {
 		if(registerInBeansXML != null) {
-			registerInBeansXML.composite.setValue(Boolean.valueOf(value));
+			registerInBeansXML.check.composite.setValue(Boolean.valueOf(value));
 		}
 	}
 
 	public boolean isToBeRegisteredInBeansXML() {
 		if(registerInBeansXML != null && alternative != null ) {
-			return alternative.composite.getValue() == Boolean.TRUE && registerInBeansXML.composite.getValue() == Boolean.TRUE;
+			return alternative.composite.getValue() == Boolean.TRUE && registerInBeansXML.isSelected();
 		}
 		return false;
 	}
 
+	protected IStatus packageChanged() {
+		IStatus result = super.packageChanged();
+		registerInBeansXML.validate();
+		return result;
+	}
+
+	protected IStatus typeNameChanged() {
+		IStatus result = super.typeNameChanged();
+		registerInBeansXML.validate();
+		return result;
+	}
 }

--- a/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/NewCDIWizardTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/NewCDIWizardTest.java
@@ -44,6 +44,7 @@ import org.jboss.tools.cdi.ui.CDIUIMessages;
 import org.jboss.tools.cdi.ui.CDIUIPlugin;
 import org.jboss.tools.cdi.ui.wizard.NewAnnotationLiteralCreationWizard;
 import org.jboss.tools.cdi.ui.wizard.NewAnnotationLiteralWizardPage;
+import org.jboss.tools.cdi.ui.wizard.NewBeanCreationWizard;
 import org.jboss.tools.cdi.ui.wizard.NewBeanWizardPage;
 import org.jboss.tools.cdi.ui.wizard.NewBeansXMLCreationWizard;
 import org.jboss.tools.cdi.ui.wizard.NewCDIElementWizard;
@@ -92,8 +93,6 @@ public class NewCDIWizardTest extends TestCase {
 		
 
 		public void init(String wizardId, String packName, String typeName) {
-			this.packName = packName;
-			this.typeName = typeName;
 			wizard = (NewElementWizard)WorkbenchUtils.findWizardByDefId(wizardId);
 			tck = ResourcesPlugin.getWorkspace().getRoot().getProject("tck");
 			jp = EclipseUtil.getJavaProject(tck);
@@ -111,8 +110,14 @@ public class NewCDIWizardTest extends TestCase {
 
 			page = (NewTypeWizardPage)dialog.getSelectedPage();
 
+			setTypeName(packName, typeName);
+		}
+
+		public void setTypeName(String packName, String typeName) {
+			this.packName = packName;
+			this.typeName = typeName;
 			page.setTypeName(typeName, true);
-			IPackageFragment pack = page.getPackageFragmentRoot().getPackageFragment(PACK_NAME);
+			IPackageFragment pack = page.getPackageFragmentRoot().getPackageFragment(packName);
 			page.setPackageFragment(pack, true);
 		}
 
@@ -368,7 +373,7 @@ public class NewCDIWizardTest extends TestCase {
 	 * 
 	 * @throws CoreException
 	 */
-	public void testNewInterceptorWizard() {
+	public void testNewInterceptorWizard() throws CoreException {
 		WizardContext context = new WizardContext();
 		context.init("org.jboss.tools.cdi.ui.wizard.NewInterceptorCreationWizard",
 				PACK_NAME, INTERCEPTOR_NAME);
@@ -382,6 +387,12 @@ public class NewCDIWizardTest extends TestCase {
 			
 			page.addInterceptorBinding(a);
 			
+			assertTrue(page.isToBeRegisteredInBeansXML());
+			context.setTypeName("com.acme", "Foo");
+			assertFalse(page.isToBeRegisteredInBeansXML());
+			context.setTypeName(PACK_NAME, INTERCEPTOR_NAME);
+			assertTrue(page.isToBeRegisteredInBeansXML());
+
 			context.wizard.performFinish();
 			
 			String text = context.getNewTypeContent();
@@ -389,7 +400,6 @@ public class NewCDIWizardTest extends TestCase {
 			assertTrue(text.contains("@Interceptor"));
 			assertTrue(text.contains("@" + EXISTING_INTERCEPTOR_BINDING_NAME));
 			
-
 			IProject tck = ResourcesPlugin.getWorkspace().getRoot().getProject("tck");
 			IFile f = tck.getFile("WebContent/WEB-INF/beans.xml");
 			XModelObject o = EclipseResourceUtil.createObjectForResource(f);


### PR DESCRIPTION
Added disabling checkbox 'Register in beans.xml' if type is already registered.
Added condition for wizard at finish to register type only if checkbox is not
disabled (and selected).
Added test that checks if checkbox is disabled/enabled for appropriate type names.
