### PR TITLE
JBIDE-13261 Conflicting handlers for org.jboss.tools.seam.ui.find.refere...

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
+++ b/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
@@ -766,7 +766,7 @@
 	      		style="push"
 				label="Find Seam Declarations"
                 tooltip="Find Seam Declarations"
-                definitionId="org.jboss.tools.seam.ui.find.references" 
+                definitionId="org.jboss.tools.seam.ui.find.declarations" 
 				menubarPath="org.eclipse.search.menu/seamSearchMenuActionsGroup"
 	      		icon="$nl$/icons/find_seam_declarations.gif"
 	      		disabledIcon="$nl$/icons/find_seam_declarations.gif"

--- a/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/search/SeamSearchVisitor.java
+++ b/seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/search/SeamSearchVisitor.java
@@ -1091,7 +1091,9 @@ public class SeamSearchVisitor {
 				}
 			}
 		} catch (IndexOutOfBoundsException e) {
-			SeamGuiPlugin.getDefault().logError(e);
+			// The exception is to be ignored because we're not calling the seq.length()
+			// due not to run through the complete file.
+			// So, IndexOutOfBoundsException here indicates the end of file.
 		}
 		return false;
 	}


### PR DESCRIPTION
...nces

Conflicting handlers error messages are fixed.
Also, extra exception processing is fixed for Search Seam References is fixed. There was a big amount of
IndexOutOfBoundsException("index must be smaller than length") error messages logged at every Search operation
because of a buggy exception handling.

```
modified:   seam/plugins/org.jboss.tools.seam.ui/plugin.xml
modified:   seam/plugins/org.jboss.tools.seam.ui/src/org/jboss/tools/seam/ui/search/SeamSearchVisitor.java
```
