### PR TITLE
JBIDE-13619 Mark Struts tooling as deprecated in release notes and optimally inside eclipse

### DIFF
--- a/struts/features/org.jboss.tools.struts.feature/feature.properties
+++ b/struts/features/org.jboss.tools.struts.feature/feature.properties
@@ -15,7 +15,7 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=Struts Tools
+featureName=Struts Tools (Deprecated)
 
 # "providerName" property - name of the company that provides the feature
 providerName=JBoss by Red Hat
@@ -25,7 +25,7 @@ updateSiteName=JBossTools Update Site
 discoverySiteName=JBossTools Development Update Site
 
 # "description" property - description of the feature
-description=Struts Tools provides basic support for Struts 1.x projects.
+description=Struts Tools provides basic support for Struts 1.x projects (Deprecated).
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=Copyright (c) 2007-2012 Exadel, Inc and Red Hat, Inc.\n\


### PR DESCRIPTION
Added "(Deprecated)" into the feature label and description.
