### PR TITLE
JBIDE-13148 Introduce an "strict taglib" validation

### DIFF
--- a/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.java
+++ b/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.java
@@ -25,10 +25,15 @@ public class JSFSeverityPreferencesMessages extends NLS {
 	//Validation Preference page
 	public static String JSFValidationConfigurationBlock_common_description;
 	
-	//Expression Language
+	//Composite Components
 	public static String JSFValidationConfigurationBlock_section_composite_components;
 	public static String JSFValidationConfigurationBlock_pb_unknownComponent_label;
 	public static String JSFValidationConfigurationBlock_pb_unknownAttribute_label;
+
+	//Strict taglib validation
+	public static String JSFValidationConfigurationBlock_section_taglib;
+	public static String JSFValidationConfigurationBlock_pb_unknownTaglibComponent_label;
+	public static String JSFValidationConfigurationBlock_pb_unknownTaglibAttribute_label;
 
 	//Faces Config
 	public static String JSFValidationConfigurationBlock_section_faces_config;

--- a/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.properties
+++ b/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.properties
@@ -1,5 +1,5 @@
 ##################################################################################
-### Copyright (c) 2007 Red Hat, Inc.
+### Copyright (c) 2007-2013 Red Hat, Inc.
 ### Distributed under license by Red Hat, Inc. All rights reserved.
 ### This program is made available under the terms of the
 ### Eclipse Public License v1.0 which accompanies this distribution,
@@ -12,10 +12,15 @@
 #Preferences Page
 JSFValidationConfigurationBlock_common_description=Select the severity level for the following optional JSF validation problems:
 
-##Expression Language
+##Composite Components
 JSFValidationConfigurationBlock_section_composite_components=Composite Components
 JSFValidationConfigurationBlock_pb_unknownComponent_label=Unknown composite component:
 JSFValidationConfigurationBlock_pb_unknownAttribute_label=Unknown composite component attribute:
+
+##Strict taglib validation
+JSFValidationConfigurationBlock_section_taglib=Tag libraries
+JSFValidationConfigurationBlock_pb_unknownTaglibComponent_label=Unknown component:
+JSFValidationConfigurationBlock_pb_unknownTaglibAttribute_label=Unknown component attribute:
 
 JSF_VALIDATION_CONFIGURATION_BLOCK_JSF_VALIDATION_CONFIGURATION_BLOCK=JSFValidationConfigurationBlock
 JSF_VALIDATION_PREFERENCE_PAGE_JSF_VALIDATOR=JSF Validation

--- a/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFValidationConfigurationBlock.java
+++ b/jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFValidationConfigurationBlock.java
@@ -37,6 +37,15 @@ public class JSFValidationConfigurationBlock extends SeverityConfigurationBlock 
 		JSFModelPlugin.PLUGIN_ID
 	);
 
+	private static SectionDescription SECTION_TAGLIBS = new SectionDescription(
+			JSFSeverityPreferencesMessages.JSFValidationConfigurationBlock_section_taglib,
+			new String[][]{
+				{JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferencesMessages.JSFValidationConfigurationBlock_pb_unknownTaglibComponent_label},
+				{JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, JSFSeverityPreferencesMessages.JSFValidationConfigurationBlock_pb_unknownTaglibAttribute_label},
+			},
+			JSFModelPlugin.PLUGIN_ID
+		);
+
 	//Faces Config
 	
 	private static SectionDescription SECTION_APPLICATION = new SectionDescription(
@@ -153,6 +162,7 @@ public class JSFValidationConfigurationBlock extends SeverityConfigurationBlock 
 
 	public static SectionDescription[] ALL_SECTIONS = new SectionDescription[] {
 		SECTION_COMPOSITE_COMPONENTS,
+		SECTION_TAGLIBS,
 		SECTION_FACES_CONFIG
 	};
 

--- a/jsf/plugins/org.jboss.tools.jsf/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.jboss.tools.jsf/META-INF/MANIFEST.MF
@@ -68,7 +68,8 @@ Require-Bundle: org.jboss.tools.jst.web;visibility:=reexport,
  org.jboss.tools.common.text.ext,
  org.eclipse.jst.jsp.ui;bundle-version="1.1.600";visibility:=reexport,
  org.jboss.tools.jst.jsp,
- org.jboss.tools.common.validation
+ org.jboss.tools.common.validation,
+ org.jboss.tools.jst.web.kb
 Bundle-Version: 3.5.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/jsf/plugins/org.jboss.tools.jsf/plugin.properties
+++ b/jsf/plugins/org.jboss.tools.jsf/plugin.properties
@@ -21,6 +21,8 @@ JSFELValidationDelegate=JSF EL Validator
 
 ComponentCompositeProblemName=JSF Composite Component Problem
 ComponentCompositeValidator=JSF Composite Component Validator
+TaglibProblemName=JSF Tag Library Problem
+TaglibValidator=JSF Tag Library Validator
 
 FacesConfigProblemName=JSF Faces Config Problem
 FacesConfigValidator=JSF Confin Validator

--- a/jsf/plugins/org.jboss.tools.jsf/plugin.xml
+++ b/jsf/plugins/org.jboss.tools.jsf/plugin.xml
@@ -497,6 +497,13 @@
       </persistent>
    </extension>
 
+   <extension id="taglibproblem" name="%TaglibProblemName" point="org.eclipse.core.resources.markers">
+      <super type="org.jboss.tools.common.validation.JBTValidationProblem">
+      </super>
+      <persistent value="true">
+      </persistent>
+   </extension>
+
    <extension id="facesconfigproblem" name="%FacesConfigProblemName" point="org.eclipse.core.resources.markers">
       <super type="org.jboss.tools.common.validation.JBTValidationProblem">
       </super>
@@ -519,6 +526,17 @@
                name="%ComponentCompositeValidator"
                id="org.jboss.tools.jsf.CompositeComponentValidator"
                problemType="org.jboss.tools.jsf.compositeproblem">
+         </validator>
+   </extension>
+
+   <extension
+   		 id="TaglibValidator"
+         point="org.jboss.tools.common.validation.validator">
+         <validator
+               class="org.jboss.tools.jsf.web.validation.StrictTaglibValidator"
+               name="%TaglibValidator"
+               id="org.jboss.tools.jsf.StrictTagLibValidator"
+               problemType="org.jboss.tools.jsf.taglibproblem">
          </validator>
    </extension>
 

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferenceInitializer.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferenceInitializer.java
@@ -33,6 +33,8 @@ public class JSFSeverityPreferenceInitializer extends AbstractPreferenceInitiali
 		for (String name : JSFSeverityPreferences.SEVERITY_OPTION_NAMES) {
 			defaultPreferences.put(name, SeverityPreferences.WARNING);
 		}
+		defaultPreferences.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, SeverityPreferences.IGNORE);
+		defaultPreferences.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, SeverityPreferences.IGNORE);
 		defaultPreferences.putInt(SeverityPreferences.MAX_NUMBER_OF_MARKERS_PREFERENCE_NAME, SeverityPreferences.DEFAULT_MAX_NUMBER_OF_MARKERS_PER_FILE);
 	}
 }

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferences.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferences.java
@@ -32,6 +32,10 @@ public class JSFSeverityPreferences extends SeverityPreferences {
 	// Mark attribute which can't be found.
 	public static final String UNKNOWN_COMPOSITE_COMPONENT_ATTRIBUTE = INSTANCE.createSeverityOption("unknownAttribute"); //$NON-NLS-1$
 
+	// Strict taglib validation
+	public static final String UNKNOWN_TAGLIB_COMPONENT = INSTANCE.createSeverityOption("unknownTaglibComponent"); //$NON-NLS-1$
+	public static final String UNKNOWN_TAGLIB_ATTRIBUTE = INSTANCE.createSeverityOption("unknownTaglibAttribute"); //$NON-NLS-1$
+
 	//Faces Config
 		//Application
 	public static final String INVALID_ACTION_LISTENER = INSTANCE.createSeverityOption("invalidActionListener"); //$NON-NLS-1$
@@ -114,8 +118,14 @@ public class JSFSeverityPreferences extends SeverityPreferences {
 		return INSTANCE.getMaxNumberOfProblemMarkersPerResource(project);
 	}
 
-	public static boolean shouldValidateEL(IProject project) {
-		return !(SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_COMPOSITE_COMPONENT_NAME)) &&
-				SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_COMPOSITE_COMPONENT_ATTRIBUTE)));
+	public static boolean shouldValidateTagLibs(IProject project) {
+		return !(SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_TAGLIB_COMPONENT)) &&
+				SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_TAGLIB_ATTRIBUTE)));
+	}
+	public static boolean shouldValidateTagLibTags(IProject project) {
+		return !SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_TAGLIB_COMPONENT));
+	}
+	public static boolean shouldValidateTagLibTagAttributes(IProject project) {
+		return !SeverityPreferences.IGNORE.equals(INSTANCE.getProjectPreference(project, UNKNOWN_TAGLIB_ATTRIBUTE));
 	}
 }

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFValidationMessage.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFValidationMessage.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2011-2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.jsf.web.validation;
 
 import org.eclipse.osgi.util.NLS;
@@ -8,6 +18,9 @@ public class JSFValidationMessage {
 
 	public static String UNKNOWN_COMPOSITE_COMPONENT_NAME;
 	public static String UNKNOWN_COMPOSITE_COMPONENT_ATTRIBUTE;
+
+	public static String UNKNOWN_TAGLIB_COMPONENT_NAME;
+	public static String UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE;
 
 	public static String SEARCHING_RESOURCES;
 	public static String VALIDATING_RESOURCE;

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/StrictTaglibValidator.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/StrictTaglibValidator.java
@@ -1,0 +1,373 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.jsf.web.validation;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.wst.sse.core.StructuredModelManager;
+import org.eclipse.wst.sse.core.internal.provisional.IModelManager;
+import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
+import org.eclipse.wst.validation.internal.core.ValidationException;
+import org.eclipse.wst.validation.internal.provisional.core.IReporter;
+import org.eclipse.wst.validation.internal.provisional.core.IValidator;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMElement;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMNode;
+import org.jboss.tools.common.el.core.resolver.ELContext;
+import org.jboss.tools.common.validation.ContextValidationHelper;
+import org.jboss.tools.common.validation.IProjectValidationContext;
+import org.jboss.tools.common.validation.IValidatingProjectTree;
+import org.jboss.tools.common.validation.PreferenceInfoManager;
+import org.jboss.tools.common.validation.ValidatorManager;
+import org.jboss.tools.jsf.JSFModelPlugin;
+import org.jboss.tools.jsf.project.JSFNature;
+import org.jboss.tools.jsf.web.validation.composite.CompositeComponentValidator;
+import org.jboss.tools.jst.web.kb.IPageContext;
+import org.jboss.tools.jst.web.kb.KbQuery;
+import org.jboss.tools.jst.web.kb.KbQuery.Type;
+import org.jboss.tools.jst.web.kb.PageContextFactory;
+import org.jboss.tools.jst.web.kb.PageProcessor;
+import org.jboss.tools.jst.web.kb.internal.KbBuilder;
+import org.jboss.tools.jst.web.kb.internal.validation.KBValidator;
+import org.jboss.tools.jst.web.kb.internal.validation.WebValidator;
+import org.jboss.tools.jst.web.kb.taglib.IAttribute;
+import org.jboss.tools.jst.web.kb.taglib.IComponent;
+import org.jboss.tools.jst.web.kb.taglib.INameSpace;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * @author Alexey Kazakov
+ */
+public class StrictTaglibValidator extends WebValidator {
+
+	public static final String ID = "org.jboss.tools.jsf.StrictTagLibValidator"; //$NON-NLS-1$
+
+	// Project libraries cache: Map<String url, Map<String tagName, Set<String> attributes>>>
+	private Map<String, Map<String, Set<String>>> cache;
+	private boolean shouldValidateTagLibTags;
+	private boolean shouldValidateTagLibTagAttributes;
+	
+	@Override
+	public void init(IProject project,
+			ContextValidationHelper validationHelper,
+			IProjectValidationContext context, IValidator manager,
+			IReporter reporter) {
+		super.init(project, validationHelper, context, manager, reporter);
+
+		cache = new HashMap<String, Map<String, Set<String>>>();
+		shouldValidateTagLibTags = shouldValidateTagLibTags(project);
+		shouldValidateTagLibTagAttributes = shouldValidateTagLibTagAttributes(project);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.common.validation.IValidator#validate(java.util.Set, org.eclipse.core.resources.IProject, org.jboss.tools.common.validation.ContextValidationHelper, org.jboss.tools.common.validation.IProjectValidationContext, org.jboss.tools.common.validation.ValidatorManager, org.eclipse.wst.validation.internal.provisional.core.IReporter)
+	 */
+	@Override
+	public IStatus validate(Set<IFile> changedFiles, IProject project,
+			ContextValidationHelper validationHelper,
+			IProjectValidationContext validationContext,
+			ValidatorManager manager, IReporter reporter)
+			throws ValidationException {
+		init(project, validationHelper, validationContext, manager, reporter);
+		Set<IFile> filesToValidate = new HashSet<IFile>();
+		for (IFile file : changedFiles) {
+			if(notValidatedYet(file) && shouldBeValidated(file)) {
+				filesToValidate.add(file);
+			}
+		}
+		for (IFile file : filesToValidate) {
+			validateFile(file);
+		}
+		cache = null;
+		return OK_STATUS;
+
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.common.validation.IValidator#validateAll(org.eclipse.core.resources.IProject, org.jboss.tools.common.validation.ContextValidationHelper, org.jboss.tools.common.validation.IProjectValidationContext, org.jboss.tools.common.validation.ValidatorManager, org.eclipse.wst.validation.internal.provisional.core.IReporter)
+	 */
+	@Override
+	public IStatus validateAll(IProject project,
+			ContextValidationHelper validationHelper,
+			IProjectValidationContext validationContext,
+			ValidatorManager manager, IReporter reporter)
+			throws ValidationException {
+		init(project, validationHelper, validationContext, manager, reporter);
+		Set<IFile> files = validationHelper.getProjectSetRegisteredFiles();
+		Set<IFile> filesToValidate = new HashSet<IFile>();
+		for (IFile file : files) {
+			if(notValidatedYet(file) && shouldBeValidated(file)) {
+				filesToValidate.add(file);
+			}
+		}
+		for (IFile file : filesToValidate) {
+			validateFile(file);
+		}
+		cache = null;
+		return OK_STATUS;
+	}
+
+	private void validateFile(IFile file) {
+		if(reporter.isCancelled()) {
+			return;
+		}
+
+		ELContext context = PageContextFactory.createPageContext(file);
+		if (context instanceof IPageContext) {
+			IModelManager manager = StructuredModelManager.getModelManager();
+			if(manager != null) {
+				IStructuredModel model = null;
+				try {
+					model = manager.getModelForRead(file);
+					if (model instanceof IDOMModel) {
+						displaySubtask(JSFValidationMessage.VALIDATING_RESOURCE, new String[]{file.getProject().getName(), file.getName()});
+						coreHelper.getValidationContextManager().addValidatedProject(this, file.getProject());
+						removeAllMessagesFromResource(file);
+
+						IDOMDocument domDocument = ((IDOMModel) model).getDocument();
+						validateChildNodes(file, domDocument.getStructuredDocument(), 
+								domDocument, (IPageContext)context);
+					}
+				} catch (CoreException e) {
+					JSFModelPlugin.getDefault().logError(e);
+				} catch (IOException e) {
+					JSFModelPlugin.getDefault().logError(e);
+				} finally {
+					if (model != null) {
+						model.releaseFromRead();
+					}
+				}
+			}
+		}
+	}
+	
+	private void validateChildNodes(IFile file, IDocument document, IDOMNode parent, IPageContext context) {
+		NodeList children = parent.getChildNodes();
+
+		for(int i = 0; children != null && i < children.getLength(); i++) {
+			Node child = children.item(i);
+			if (child instanceof IDOMNode) {
+				validateNode(file, document, (IDOMNode)child, context);
+				validateChildNodes(file, document, (IDOMNode)child, context);
+			}
+		}
+	}
+	
+	private void validateNode(IFile file, IDocument document, IDOMNode node, IPageContext context) {
+		if (!(node instanceof IDOMElement))
+			return;
+		
+		String nodeName = node.getNodeName();
+		int offset = node.getStartOffset();
+		
+		int prefixDivider = nodeName.indexOf(':');
+		if (prefixDivider == -1) 
+			return;
+		
+		String prefix = nodeName.substring(0, prefixDivider);
+		String name = nodeName.substring(prefixDivider + 1);
+		String uri = getUri(context, prefix, offset);
+	
+		// Check that tag exists
+		// If the tag isn't cached - get its attributes and cache them
+		Map<String, Set<String>> tagCache = cache.get(uri);
+		if (tagCache == null) {
+			tagCache = new HashMap<String, Set<String>>();
+			cache.put(uri, tagCache);
+		}
+		
+		if (!tagCache.containsKey(nodeName)) {
+			KbQuery kbQuery = new KbQuery();
+			kbQuery.setPrefix(prefix);
+			kbQuery.setUri(uri);
+			kbQuery.setMask(false); 
+			kbQuery.setType(Type.TAG_NAME);
+			kbQuery.setOffset(offset);
+			kbQuery.setValue(nodeName); 
+
+			IComponent[] components = PageProcessor.getInstance().getComponents(kbQuery, context, false);
+			if (components.length > 0) {
+				Set<String> tagAttributes = new HashSet<String>();
+				tagCache.put(name, tagAttributes); 
+
+				for (IComponent comp : components) {
+					IAttribute[] attributes = comp.getAttributes();
+					for (IAttribute attribute : attributes) {
+						tagAttributes.add(attribute.getName());
+					}
+				}
+			}
+		}
+		
+		if (!tagCache.containsKey(name)) {
+			if(shouldValidateTagLibTags) {
+				if (null == unknownTag(file, offset + 1, nodeName.length(), nodeName)) {
+					return; // if unknownTag() returns null then no further validation is needed
+				}
+			}
+		} else if (shouldValidateTagLibTagAttributes) {
+			NamedNodeMap nodeAttributes = node.getAttributes();
+			if (nodeAttributes != null && nodeAttributes.getLength() > 0) {
+				Set<String> tagAttributes = tagCache.get(name);
+				for (int i = 0; i < nodeAttributes.getLength(); i++) {
+					Node attribute = nodeAttributes.item(i);
+					String attributeName = attribute.getNodeName();
+					int attributeOffset = (attribute instanceof IDOMNode ? ((IDOMNode)attribute).getStartOffset() : offset);
+
+					if (tagAttributes == null || !tagAttributes.contains(attributeName)) {
+						if (null == unknownAttribute(file, attributeOffset, attributeName.length(), nodeName, attributeName))
+							return; // if unknownAttribute() returns null then no further validation is needed
+					}
+				}
+			}
+		}
+	}
+
+	private String getUri(IPageContext context, String prefix, int offset) {
+		if (prefix == null)
+			return null;
+		
+		Map<String, List<INameSpace>> nameSpaces = context.getNameSpaces(offset);
+		if (nameSpaces == null || nameSpaces.isEmpty())
+			return null;
+		
+		for (List<INameSpace> nameSpace : nameSpaces.values()) {
+			for (INameSpace n : nameSpace) {
+				if (prefix.equals(n.getPrefix())) {
+					return n.getURI();
+				}
+			}
+		}
+		return null;
+	}
+	
+	private IMarker unknownAttribute(IFile target, int offset, int length, String tagName, String attributeName) {
+		return addProblem(JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE, JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, new String[]{attributeName, tagName}, length, offset, target);
+	}
+
+	private IMarker unknownTag(IFile target, int offset, int length, String tagName) {
+		return addProblem(JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_NAME, JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, new String[]{tagName}, length, offset, target);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.common.validation.IValidator#getId()
+	 */
+	@Override
+	public String getId() {
+		return ID;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.common.validation.IValidator#getBuilderId()
+	 */
+	@Override
+	public String getBuilderId() {
+		return KbBuilder.BUILDER_ID;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.internal.validation.WebValidator#shouldValidateJavaSources()
+	 */
+	@Override
+	protected boolean shouldValidateJavaSources() {
+		return false;
+	}
+
+	private static final String BUNDLE_NAME = "org.jboss.tools.jsf.web.validation.messages";
+
+	/* (non-Javadoc)
+	 * @see org.jboss.tools.common.validation.TempMarkerManager#getMessageBundleName()
+	 */
+	@Override
+	protected String getMessageBundleName() {
+		return BUNDLE_NAME;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.validation.IValidator#getValidatingProjects(org.eclipse.core.resources.IProject)
+	 */
+	public IValidatingProjectTree getValidatingProjects(IProject project) {
+		return createSimpleValidatingProjectTree(project);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.validation.IValidator#shouldValidate(org.eclipse.core.resources.IProject)
+	 */
+	public boolean shouldValidate(IProject project) {
+		try {
+			return project != null 
+					&& project.isAccessible() 
+					&& project.hasNature(JSFNature.NATURE_ID) 
+					&& validateBuilderOrder(project)
+					&& isEnabled(project);
+		} catch (CoreException e) {
+			JSFModelPlugin.getDefault().logError(e);
+		}
+		return false;
+	}
+
+	private boolean validateBuilderOrder(IProject project) throws CoreException {
+		return KBValidator.validateBuilderOrder(project, getBuilderId(), getId(), JSFSeverityPreferences.getInstance());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.validation.IValidator#isEnabled(org.eclipse.core.resources.IProject)
+	 */
+	public boolean isEnabled(IProject project) {
+		return JSFSeverityPreferences.isValidationEnabled(project) && JSFSeverityPreferences.shouldValidateTagLibs(project);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.internal.validation.ValidationErrorManager#getPreference(org.eclipse.core.resources.IProject, java.lang.String)
+	 */
+	protected String getPreference(IProject project, String preferenceKey) {
+		return JSFSeverityPreferences.getInstance().getProjectPreference(project, preferenceKey);
+	}
+
+	protected boolean shouldValidateTagLibTags(IProject project) {
+		return JSFSeverityPreferences.shouldValidateTagLibTags(project);
+	}
+
+	protected boolean shouldValidateTagLibTagAttributes(IProject project) {
+		return JSFSeverityPreferences.shouldValidateTagLibTagAttributes(project);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see org.jboss.tools.jst.web.kb.internal.validation.ValidationErrorManager#getMaxNumberOfMarkersPerFile(org.eclipse.core.resources.IProject)
+	 */
+	public int getMaxNumberOfMarkersPerFile(IProject project) {
+		return JSFSeverityPreferences.getMaxNumberOfProblemMarkersPerFile(project);
+	}
+
+	@Override
+	public void registerPreferenceInfo() {
+		PreferenceInfoManager.register(getProblemType(), new CompositeComponentValidator.CompositeComponentPreferenceInfo());
+	}
+}

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/composite/CompositeComponentValidator.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/composite/CompositeComponentValidator.java
@@ -387,7 +387,7 @@ public class CompositeComponentValidator extends WebValidator {
 		PreferenceInfoManager.register(getProblemType(), new CompositeComponentPreferenceInfo());
 	}
 	
-	class CompositeComponentPreferenceInfo implements IPreferenceInfo{
+	public static class CompositeComponentPreferenceInfo implements IPreferenceInfo{
 
 		@Override
 		public String getPreferencePageId() {

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/messages.properties
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/messages.properties
@@ -1,6 +1,10 @@
-#
+#Composite component
 UNKNOWN_COMPOSITE_COMPONENT_NAME=Unknown composite component "{0}"
 UNKNOWN_COMPOSITE_COMPONENT_ATTRIBUTE=Unknown attribute "{0}" of composite component "{1}"
+
+#Taglib component
+UNKNOWN_TAGLIB_COMPONENT_NAME=Unknown component "{0}"
+UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE=Unknown attribute "{0}" of component "{1}"
 
 #Messages for Progress Monitor
 SEARCHING_RESOURCES=project "{0}"; searching resources for validation (JSF Validator)

--- a/jsf/tests/org.jboss.tools.jsf.test/projects/JSFKickStartOldFormat/WebContent/strictTaglibValidation.xhtml
+++ b/jsf/tests/org.jboss.tools.jsf.test/projects/JSFKickStartOldFormat/WebContent/strictTaglibValidation.xhtml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="windows-1251"?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+                      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:ui="http://java.sun.com/jsf/facelets"
+	xmlns:h="http://java.sun.com/jsf/html">
+
+	<h:outputTextLine value="Text Value"/>
+	<h:outputText textLineValue="Another Text Value"/>
+	
+</ui:composition>

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/JsfAllTests.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/JsfAllTests.java
@@ -30,6 +30,7 @@ import org.jboss.tools.jsf.test.validation.FacesConfigValidatorTest;
 import org.jboss.tools.jsf.test.validation.JSF2ComponentsInClassFolderTest;
 import org.jboss.tools.jsf.test.validation.JSF2ComponentsValidatorTest;
 import org.jboss.tools.jsf.test.validation.ParameterizedClassValidationTest;
+import org.jboss.tools.jsf.test.validation.StrictTaglibValidatorTest;
 import org.jboss.tools.jsf.test.validation.VarAttributesTest;
 import org.jboss.tools.jsf.test.validation.WTPValidationTest;
 import org.jboss.tools.jsf.test.validation.WebContentTest;
@@ -66,7 +67,8 @@ public class JsfAllTests {
 				ELValidatorTest.class,
 				ELVariableRefactoringTest.class,
 				MethodRefactoringTest.class,
-				MessagePropertyRefactoringTest.class
+				MessagePropertyRefactoringTest.class,
+				StrictTaglibValidatorTest.class
 				),
 				"org.jboss.tools.jsf.test", "projects/JSFKickStartOldFormat", //$NON-NLS-1$ //$NON-NLS-2$
 				"JSFKickStartOldFormat")); //$NON-NLS-1$

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/ELValidatorTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/ELValidatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2012 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -57,12 +57,12 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 	}
 
 	public void testPropertyInBrackets() throws CoreException, ValidationException {
-		assertMarkerIsCreatedForLine(
+		MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 				"WebContent/pages/inputname.jsp",
 				ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 				new Object[] {"'age1'"},
 				20);
-		assertMarkerIsNotCreatedForLine(
+		MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
 				"WebContent/pages/inputname.jsp",
 				ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 				new Object[] {"'age'"},
@@ -77,7 +77,7 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 		try {
 			copyContentsFile("WebContent/WEB-INF/faces-config.xml", "WebContent/WEB-INF/faces-config.1");
 
-			assertMarkerIsCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 					"WebContent/testElRevalidation.xhtml",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 					new Object[] {"user"},
@@ -86,7 +86,7 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 			// Check if the validator was not invoked.
 			copyContentsFile("WebContent/WEB-INF/faces-config.xml", "WebContent/WEB-INF/faces-config.original");
 
-			assertMarkerIsNotCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
 					"WebContent/testElRevalidation.xhtml",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 					new Object[] {"user"},
@@ -106,7 +106,7 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 		try {
 			copyContentsFile("WebContent/WEB-INF/faces-config.xml", "WebContent/WEB-INF/faces-config.1");
 
-			assertMarkerIsCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 					"WebContent/testElRevalidation.xhtml",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 					new Object[] {"user"},
@@ -115,7 +115,7 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 			IFile file = project.getFile("WebContent/testElRevalidation.xhtml");
 			file.deleteMarkers(EL_VALIDATOR_MARKER_TYPE, true, IResource.DEPTH_ZERO);
 
-			assertMarkerIsNotCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
 					"WebContent/testElRevalidation.xhtml",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 					new Object[] {"user"},
@@ -127,7 +127,7 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 			file = project.getFile("WebContent/WEB-INF/faces-config.xml");
 			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
 
-			assertMarkerIsNotCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
 					"WebContent/testElRevalidation.xhtml",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_PROPERTY_NAME,
 					new Object[] {"user"},
@@ -177,12 +177,12 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 		store.setValue(ELSeverityPreferences.UNKNOWN_EL_VARIABLE_NAME, ELSeverityPreferences.ERROR);
 
 		try {
-			assertMarkerIsCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 					"WebContent/pages/maxNumberOfMarkers.jsp",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_NAME,
 					new Object[] {"wrongUserName"},
 					3);
-			assertMarkerIsNotCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
 					"WebContent/pages/maxNumberOfMarkers.jsp",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_NAME,
 					new Object[] {"wrongUserName2"},
@@ -190,12 +190,12 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 
 			store.setValue(SeverityPreferences.MAX_NUMBER_OF_MARKERS_PREFERENCE_NAME, max);
 
-			assertMarkerIsCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 					"WebContent/pages/maxNumberOfMarkers.jsp",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_NAME,
 					new Object[] {"wrongUserName"},
 					3);
-			assertMarkerIsCreatedForLine(
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
 					"WebContent/pages/maxNumberOfMarkers.jsp",
 					ELValidationMessages.UNKNOWN_EL_VARIABLE_NAME,
 					new Object[] {"wrongUserName2"},
@@ -377,47 +377,4 @@ public class ELValidatorTest extends AbstractResourceMarkerTest{
 		return helper;
 	}
 
-	private void assertMarkerIsCreatedForLine(String fileName, String template, Object[] parameters, int lineNumber) throws CoreException{
-		assertMarkerIsCreatedForLine(fileName, template, parameters, lineNumber, true);
-	}
-
-	private void assertMarkerIsCreatedForLine(String fileName, String template, Object[] parameters, int lineNumber, boolean validate) throws CoreException{
-		String messagePattern = MessageFormat.format(template, parameters);
-		IFile file = project.getFile(fileName);
-
-		if(validate) {
-			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
-		}
-
-		IMarker[] markers = file.findMarkers(null, true, IResource.DEPTH_INFINITE);
-		for (int i = 0; i < markers.length; i++) {
-			String message = markers[i].getAttribute(IMarker.MESSAGE, ""); //$NON-NLS-1$
-			int line = markers[i].getAttribute(IMarker.LINE_NUMBER, -1); //$NON-NLS-1$
-			if(message.equals(messagePattern) && line == lineNumber)
-				return;
-		}
-		fail("Marker "+messagePattern+" for line - "+lineNumber+" not found");
-	}
-
-	private void assertMarkerIsNotCreatedForLine(String fileName, String template, Object[] parameters, int lineNumber) throws CoreException{
-		assertMarkerIsNotCreatedForLine(fileName, template, parameters, lineNumber, true);
-	}
-
-	private void assertMarkerIsNotCreatedForLine(String fileName, String template, Object[] parameters, int lineNumber, boolean validate) throws CoreException{
-		String messagePattern = MessageFormat.format(template, parameters);
-		IFile file = project.getFile(fileName);
-
-		if(validate) {
-			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
-		}
-
-		IMarker[] markers = file.findMarkers(null, true, IResource.DEPTH_INFINITE);
-		for (int i = 0; i < markers.length; i++) {
-			String message = markers[i].getAttribute(IMarker.MESSAGE, ""); //$NON-NLS-1$
-			int line = markers[i].getAttribute(IMarker.LINE_NUMBER, -1); //$NON-NLS-1$
-			if(message.equals(messagePattern) && line == lineNumber){
-				fail("Marker "+messagePattern+" for line - "+lineNumber+" has been found");
-			}
-		}
-	}
 }

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/MarkerAssertUtil.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/MarkerAssertUtil.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jsf.test.validation;
+
+import java.text.MessageFormat;
+
+import junit.framework.Assert;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.wst.validation.ValidationFramework;
+
+public class MarkerAssertUtil extends Assert {
+	public static void assertMarkerIsCreatedForLine(IProject project, String fileName, String template, Object[] parameters, int lineNumber) throws CoreException{
+		assertMarkerIsCreatedForLine(project, fileName, template, parameters, lineNumber, true);
+	}
+
+	public static void assertMarkerIsCreatedForLine(IProject project, String fileName, String template, Object[] parameters, int lineNumber, boolean validate) throws CoreException{
+		String messagePattern = MessageFormat.format(template, parameters);
+		IFile file = project.getFile(fileName);
+
+		if(validate) {
+			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
+		}
+
+		IMarker[] markers = file.findMarkers(null, true, IResource.DEPTH_INFINITE);
+		for (int i = 0; i < markers.length; i++) {
+			String message = markers[i].getAttribute(IMarker.MESSAGE, ""); //$NON-NLS-1$
+			int line = markers[i].getAttribute(IMarker.LINE_NUMBER, -1); //$NON-NLS-1$
+			if(message.equals(messagePattern) && line == lineNumber)
+				return;
+		}
+		fail("Marker "+messagePattern+" for line - "+lineNumber+" not found");
+	}
+
+	public static void assertMarkerIsNotCreatedForLine(IProject project, String fileName, String template, Object[] parameters, int lineNumber) throws CoreException{
+		assertMarkerIsNotCreatedForLine(project, fileName, template, parameters, lineNumber, true);
+	}
+
+	public static void assertMarkerIsNotCreatedForLine(IProject project, String fileName, String template, Object[] parameters, int lineNumber, boolean validate) throws CoreException{
+		String messagePattern = MessageFormat.format(template, parameters);
+		IFile file = project.getFile(fileName);
+
+		if(validate) {
+			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
+		}
+
+		IMarker[] markers = file.findMarkers(null, true, IResource.DEPTH_INFINITE);
+		for (int i = 0; i < markers.length; i++) {
+			String message = markers[i].getAttribute(IMarker.MESSAGE, ""); //$NON-NLS-1$
+			int line = markers[i].getAttribute(IMarker.LINE_NUMBER, -1); //$NON-NLS-1$
+			if(message.equals(messagePattern) && line == lineNumber){
+				fail("Marker "+messagePattern+" for line - "+lineNumber+" has been found");
+			}
+		}
+	}
+}

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/StrictTaglibValidatorTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/StrictTaglibValidatorTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jsf.test.validation;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.wst.validation.ValidationFramework;
+import org.eclipse.wst.validation.internal.core.ValidationException;
+import org.jboss.tools.jsf.web.validation.JSFSeverityPreferences;
+import org.jboss.tools.jsf.web.validation.JSFValidationMessage;
+import org.jboss.tools.test.util.ProjectImportTestSetup;
+import org.jboss.tools.tests.AbstractResourceMarkerTest;
+
+public class StrictTaglibValidatorTest extends AbstractResourceMarkerTest {
+	public static final String STRICT_TAGLIB_VALIDATOR_MARKER_TYPE = "org.jboss.tools.jst.web.kb.elproblem";
+	
+	private static final String TEST_FILE = "WebContent/strictTaglibValidation.xhtml";
+		
+	protected void setUp() throws Exception {
+		project = ProjectImportTestSetup.loadProject("JSFKickStartOldFormat");
+	}
+	
+	public void testStrictTagLibValidator() throws CoreException, ValidationException {
+		
+		// Get the preferences values
+		IEclipsePreferences prefs = JSFSeverityPreferences.getInstance().getProjectPreferences(project);
+		String unknownTaglibComponentPreferenceValue = prefs.get(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferences.IGNORE);
+		String unknownTaglibAttributePreferenceValue = prefs.get(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferences.IGNORE);
+
+		IFile file = project.getFile(TEST_FILE);
+		try {
+			// Disable the Strict Taglib Components/Attributes validation
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferences.IGNORE);
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, JSFSeverityPreferences.IGNORE);
+			file.deleteMarkers(STRICT_TAGLIB_VALIDATOR_MARKER_TYPE, true, IResource.DEPTH_ZERO);
+			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_NAME,
+					new Object[] {"h:outputTextLine"},
+					8, false);
+			
+			MarkerAssertUtil.assertMarkerIsNotCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE,
+					new Object[] {"textLineValue", "h:outputText"},
+					9, false);
+
+			// Set the WARMING Severity for the Strict Taglib Components/Attributes validator
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferences.WARNING);
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, JSFSeverityPreferences.WARNING);
+			file.deleteMarkers(STRICT_TAGLIB_VALIDATOR_MARKER_TYPE, true, IResource.DEPTH_ZERO);
+			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_NAME,
+					new Object[] {"h:outputTextLine"},
+					8, false);
+			
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE,
+					new Object[] {"textLineValue", "h:outputText"},
+					9, false);
+			
+			// Set the ERROR Severity for the Strict Taglib Components/Attributes validator
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, JSFSeverityPreferences.ERROR);
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, JSFSeverityPreferences.ERROR);
+			file.deleteMarkers(STRICT_TAGLIB_VALIDATOR_MARKER_TYPE, true, IResource.DEPTH_ZERO);
+			ValidationFramework.getDefault().validate(file, new NullProgressMonitor());
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_NAME,
+					new Object[] {"h:outputTextLine"},
+					8, false);
+			
+			MarkerAssertUtil.assertMarkerIsCreatedForLine(project,
+					TEST_FILE,
+					JSFValidationMessage.UNKNOWN_TAGLIB_COMPONENT_ATTRIBUTE,
+					new Object[] {"textLineValue", "h:outputText"},
+					9, false);
+
+		} finally {
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_COMPONENT, unknownTaglibComponentPreferenceValue);
+			prefs.put(JSFSeverityPreferences.UNKNOWN_TAGLIB_ATTRIBUTE, unknownTaglibAttributePreferenceValue);
+		}
+	}
+}


### PR DESCRIPTION
Strict Taglib validator is created. JUnit Test is created for the issue.

```
modified:   jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.java
modified:   jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFSeverityPreferencesMessages.properties
modified:   jsf/plugins/org.jboss.tools.jsf.ui/src/org/jboss/tools/jsf/ui/preferences/JSFValidationConfigurationBlock.java
modified:   jsf/plugins/org.jboss.tools.jsf/META-INF/MANIFEST.MF
modified:   jsf/plugins/org.jboss.tools.jsf/plugin.properties
modified:   jsf/plugins/org.jboss.tools.jsf/plugin.xml
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferenceInitializer.java
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFSeverityPreferences.java
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/JSFValidationMessage.java
new file:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/StrictTaglibValidator.java
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/composite/CompositeComponentValidator.java
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/web/validation/messages.properties
new file:   jsf/tests/org.jboss.tools.jsf.test/projects/JSFKickStartOldFormat/WebContent/strictTaglibValidation.xhtml
modified:   jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/JsfAllTests.java
modified:   jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/ELValidatorTest.java
new file:   jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/MarkerAssertUtil.java
new file:   jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/test/validation/StrictTaglibValidatorTest.java
```
