### PR TITLE
JBIDE-13941 Marker in CDI Seam config disappears after modifications

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
@@ -1572,6 +1572,10 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 				collectAllRelatedInjectionsForNode(nodes, relatedResources);
 				nodes = cdiProject.getInterceptorClasses();
 				collectAllRelatedInjectionsForNode(nodes, relatedResources);
+				Set<IPath> dd = getCDIContext(validatingResource).getDependencies().getDirectDependencies(validatingResource.getFullPath());
+				if(dd != null) {
+					relatedResources.addAll(dd);
+				}
 			}
 		}
 	}

--- a/cdi/tests/org.jboss.tools.cdi.seam.config.core.test/src/org/jboss/tools/cdi/seam/config/core/test/SeamConfigValidationTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.seam.config.core.test/src/org/jboss/tools/cdi/seam/config/core/test/SeamConfigValidationTest.java
@@ -145,6 +145,8 @@ public class SeamConfigValidationTest extends TestCase {
 		GenericBeanValidationTest.removeFile(project, path);
 		String message = NLS.bind(SeamConfigValidationMessages.UNRESOLVED_TYPE, "org.jboss.beans.validation.test.MyBean2");
 		AbstractResourceMarkerTest.assertMarkerIsCreated(f, message, 8);
+
+		AbstractResourceMarkerTest.assertMarkerIsCreated(f, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS, 61, 71, 102, 109, 124);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.seam.config.core.test/src/org/jboss/tools/cdi/seam/config/core/test/v30/SeamConfigValidationTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.seam.config.core.test/src/org/jboss/tools/cdi/seam/config/core/test/v30/SeamConfigValidationTest.java
@@ -145,6 +145,8 @@ public class SeamConfigValidationTest extends TestCase {
 		GenericBeanValidationTest.removeFile(project, path);
 		String message = NLS.bind(SeamConfigValidationMessages.UNRESOLVED_TYPE, "org.jboss.beans.validation.test.MyBean2");
 		AbstractResourceMarkerTest.assertMarkerIsCreated(f, message, 8);
+
+		AbstractResourceMarkerTest.assertMarkerIsCreated(f, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS, 61, 71, 102, 109, 124);
 	}
 
 	/**


### PR DESCRIPTION
Provided revalidation of beans declared in beans.xml.
Test testAddClassToResolveNode is modified to check that
after a modification which triggers revalidation of beans.xml
markers  'No bean is eligible for injection...' do not disappear.
