### PR TITLE
JBIDE-8428 Content assist inside #{} in text element of xhtml shows JSF ...

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.seam.core/src/org/jboss/tools/cdi/seam/core/international/el/CDIInternationalMessagesELResolver.java
+++ b/cdi/plugins/org.jboss.tools.cdi.seam.core/src/org/jboss/tools/cdi/seam/core/international/el/CDIInternationalMessagesELResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Red Hat, Inc.
+ * Copyright (c) 2011-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -298,8 +298,10 @@ public class CDIInternationalMessagesELResolver extends AbstractELCompletionEngi
 				for (Variable var : resolvedVariables) {
 					String varName = var.getName();
 					if(varName.startsWith(operand.getText())) {
-						TextProposal proposal = new TextProposal();
+						MessagesELTextProposal proposal = new MessagesELTextProposal();
 						proposal.setReplacementString(varName.substring(operand.getLength()));
+						proposal.setLabel(varName);
+						proposal.setPropertyName(null); // Since it's not a property
 						proposal.setImageDescriptor(getELProposalImageForMember(null));
 						proposals.add(proposal);
 					}

--- a/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/model/JSF2CCAttrsELCompletionEngine.java
+++ b/jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/model/JSF2CCAttrsELCompletionEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2011 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -28,6 +28,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.graphics.Image;
 import org.jboss.tools.common.el.core.ca.AbstractELCompletionEngine;
+import org.jboss.tools.common.el.core.ca.ELTextProposal;
 import org.jboss.tools.common.el.core.model.ELArgumentInvocation;
 import org.jboss.tools.common.el.core.model.ELExpression;
 import org.jboss.tools.common.el.core.model.ELInvocationExpression;
@@ -225,7 +226,7 @@ public class JSF2CCAttrsELCompletionEngine extends AbstractELCompletionEngine<IV
 			for (IVariable var : resolvedVariables) {
 				String varName = var.getName();
 				if(varName.startsWith(operand.getText())) {
-					TextProposal proposal = new TextProposal();
+					ELTextProposal proposal = new ELTextProposal();
 					proposal.setReplacementString(varName.substring(operand.getLength()));
 					proposal.setImageDescriptor(getELProposalImageForMember(null));
 					proposals.add(proposal);
@@ -248,7 +249,7 @@ public class JSF2CCAttrsELCompletionEngine extends AbstractELCompletionEngine<IV
 			for (IVariable var : resolvedVariables) {
 				String varName = var.getName();
 				if(operand.getLength()<=varName.length()) {
-					TextProposal proposal = new TextProposal();
+					ELTextProposal proposal = new ELTextProposal();
 					proposal.setReplacementString(varName.substring(operand.getLength()));
 					proposal.setLabel(varName);
 					proposal.setImageDescriptor(getELProposalImageForMember(null));
@@ -462,7 +463,7 @@ public class JSF2CCAttrsELCompletionEngine extends AbstractELCompletionEngine<IV
 					}
 				} else if (proposal.startsWith(filter)) {
 					// This is used for CA.
-					TextProposal kbProposal = new TextProposal();
+					ELTextProposal kbProposal = new ELTextProposal();
 					kbProposal.setReplacementString(proposal.substring(filter.length()));
 					kbProposal.setLabel(proposal);
 					kbProposal.setImageDescriptor(getELProposalImageForMember(null));
@@ -514,7 +515,7 @@ public class JSF2CCAttrsELCompletionEngine extends AbstractELCompletionEngine<IV
 					}
 				} else if (proposal.startsWith(filter)) {
 					// This is used for CA.
-					TextProposal kbProposal = new TextProposal();
+					ELTextProposal kbProposal = new ELTextProposal();
 
 					String replacementString = proposal.substring(filter.length());
 					if (bSurroundWithQuotes) {
@@ -545,14 +546,14 @@ public class JSF2CCAttrsELCompletionEngine extends AbstractELCompletionEngine<IV
 			if (key == null || key.length() == 0)
 				continue;
 			if (key.indexOf('.') != -1) {
-				TextProposal proposal = new TextProposal();
+				ELTextProposal proposal = new ELTextProposal();
 				proposal.setReplacementString("['" + key + "']"); //$NON-NLS-1$ //$NON-NLS-2$
 				proposal.setLabel("['" + key + "']");
 				proposal.setImageDescriptor(getELProposalImageForMember(null));
 
 				kbProposals.add(proposal);
 			} else {
-				TextProposal proposal = new TextProposal();
+				ELTextProposal proposal = new ELTextProposal();
 				proposal.setReplacementString(key);
 				proposal.setLabel(key);
 				proposal.setImageDescriptor(getELProposalImageForMember(null));

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAELNoTagProposalsInELTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAELNoTagProposalsInELTest.java
@@ -1,0 +1,81 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.jsf.jsp.ca.test;
+
+import java.util.List;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.jboss.tools.common.base.test.contentassist.CATestUtil;
+import org.jboss.tools.jst.jsp.contentassist.AutoELContentAssistantProposal;
+import org.jboss.tools.jst.jsp.test.ca.ContentAssistantTestCase;
+import org.jboss.tools.test.util.JobUtils;
+import org.jboss.tools.test.util.ProjectImportTestSetup;
+
+/**
+ * JUnit Test for the following issue(s):
+ * - JBIDE-8428
+ * 
+ * @author Victor V. Rubezhny
+ */
+public class CAELNoTagProposalsInELTest  extends ContentAssistantTestCase {
+	private static final String PROJECT_NAME = "JSF2KickStartWithoutLibs";
+	private static final String PAGE_NAME = "WebContent/pages/inputname.xhtml";
+	
+	private static final String INSERT_BEFORE = "</ui:define>";
+	private static final String EL_LBRACE = "#{";
+	private static final String EL_RBRACE = "}";
+
+	public void setUp() throws Exception {
+		project = ProjectImportTestSetup.loadProject(PROJECT_NAME);
+	}
+
+	/*
+	 * The test case for JBIDE-8428
+	 */
+	public void testELApplyMethodProposal() {
+		openEditor(PAGE_NAME);
+		try {
+
+			assertNotNull("Text Viewer not found", getViewer());
+			IDocument document = getViewer().getDocument();
+			assertNotNull("Can't obtain a test Document.", document);
+
+			String documentContent = document.get();
+			int start = (documentContent == null ? -1 : documentContent
+					.indexOf(INSERT_BEFORE));
+			assertFalse("Required text '" + INSERT_BEFORE
+					+ "' not found in document", (start == -1));
+
+			String documentContentModified = documentContent.substring(0,start)
+						+ EL_LBRACE + EL_RBRACE 
+						+ documentContent.substring(start);
+
+			int offsetToTest = start + EL_LBRACE.length();
+
+			jspTextEditor.setText(documentContentModified);
+
+			JobUtils.waitForIdle();
+
+			List<ICompletionProposal> res = CATestUtil.collectProposals(
+					getContentAssistant(), getViewer(), offsetToTest);
+
+			assertTrue("Content Assistant returned no proposals",
+					(res != null && res.size() > 0));
+
+			for (ICompletionProposal p : res) {
+				assertTrue("Non-EL proposal returned inside #{}", (p instanceof AutoELContentAssistantProposal));
+			}
+		} finally {
+			closeEditor();
+		}
+	}
+}

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/JsfUiAllTests.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/JsfUiAllTests.java
@@ -21,6 +21,7 @@ import org.jboss.tools.jsf.jsp.ca.test.CAELApplyMethodProposalTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAELBeanPropertyTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAELFunctionsTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAELInsideTagBodyInJspFileTest;
+import org.jboss.tools.jsf.jsp.ca.test.CAELNoTagProposalsInELTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAForCompositeComponentTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAForELJavaAndJSTCompareTest;
 import org.jboss.tools.jsf.jsp.ca.test.CAForELinStyleTest;
@@ -154,7 +155,8 @@ public class JsfUiAllTests {
 				CAELBeanPropertyTest.class,
 				JSFAsYouTypeInJavaValidationTest.class,
 				JSFAsYouTypeValidationTest.class,
-				CAJsfPredictiveTagNameProposalsTest.class), "org.jboss.tools.jsf.base.test", //$NON-NLS-1$
+				CAJsfPredictiveTagNameProposalsTest.class,
+				CAELNoTagProposalsInELTest.class), "org.jboss.tools.jsf.base.test", //$NON-NLS-1$
 				new String[] { "projects/JSF2KickStartWithoutLibs", }, //$NON-NLS-1$
 				new String[] { "JSF2KickStartWithoutLibs" })); //$NON-NLS-1$
 


### PR DESCRIPTION
...tags as proposals

The issue is fixed. All the Non-EL proposals are filtered out from the proposal list when the Content Assist
is invoked from the position inside EL (#{...}).
JUnit Test org.jboss.tools.jsf.jsp.ca.test.CAELNoTagProposalsInELTest

```
modified:   cdi/plugins/org.jboss.tools.cdi.seam.core/src/org/jboss/tools/cdi/seam/core/international/el/CDIInternationalMessagesELResolver.java
modified:   jsf/plugins/org.jboss.tools.jsf/src/org/jboss/tools/jsf/model/JSF2CCAttrsELCompletionEngine.java
new file:   jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAELNoTagProposalsInELTest.java
modified:   jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/JsfUiAllTests.java
```
