### PR TITLE
JBIDE-14735 Improve text formatting when dropping widgets from Palette v...

### DIFF
--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/TestPalette.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/TestPalette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2012 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -209,8 +209,8 @@ public class TestPalette  extends TestCase {
 		ISourceViewer v = (ISourceViewer)jspEditor.getSourceEditor().getAdapter(ISourceViewer.class);
 		assertNotNull(v);
 		Properties p = new Properties();
-		p.setProperty(PaletteInsertHelper.PROPOPERTY_TAG_NAME, "containsIgnoreCase");
-		p.setProperty(PaletteInsertHelper.PROPOPERTY_START_TEXT, "${containsIgnoreCase('', '')}");
+		p.setProperty(PaletteInsertHelper.PROPERTY_TAG_NAME, "containsIgnoreCase");
+		p.setProperty(PaletteInsertHelper.PROPERTY_START_TEXT, "${containsIgnoreCase('', '')}");
 		p.setProperty(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI, "http://java.sun.com/jsp/jstl/functions");
 		
 		//Execute insert into editor.


### PR DESCRIPTION
...iew

Issue is fixed. Prev. sibling/parent tag is used to calculate the indent of the template text
that is to be inserted. 'Use spaces' option is taken into account. All indents that are inserted are
recalculated by using tabs (until it's possible) then spaces.
JUnit Test is added for the issue: org.jboss.tools.common.model.ui.views.palette.test.PaletteInsertHelperTest
Typoo in constant names are fixed
