### PR TITLE
JBIDE-14938  Content assist for JSF components does not consider composite-library-name

### DIFF
--- a/jsf/tests/org.jboss.tools.jsf.test/projects/TestKbModel/WebContent/WEB-INF/facelets-taglib.xml
+++ b/jsf/tests/org.jboss.tools.jsf.test/projects/TestKbModel/WebContent/WEB-INF/facelets-taglib.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<facelet-taglib version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facelettaglibrary_2_0.xsd">
+ <display-name>h2</display-name>
+ <namespace>myFaceletWithCompositeLibraryName</namespace>
+ <composite-library-name>demo</composite-library-name>
+</facelet-taglib>

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/kb/test/JsfKbAllTests.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/kb/test/JsfKbAllTests.java
@@ -38,6 +38,6 @@ public class JsfKbAllTests {
 				new String[]{"projects/utility", "projects/webapp"},
 				new String[]{"utility", "webapp"});
 		suiteAll.addTest(testSetup);
-		return testSetup;
+		return suiteAll;
 	}
 }

--- a/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/kb/test/KbModelTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.test/src/org/jboss/tools/jsf/kb/test/KbModelTest.java
@@ -70,4 +70,15 @@ public class KbModelTest extends TestCase {
 		assertNotNull(c.getAttribute("label2"));
 	}
 
+	public void testFaceletLibraryWithCompositeLibraryName() {
+		IKbProject kbProject = getKbProject();
+		ITagLibrary[] ls = kbProject.getTagLibraries("myFaceletWithCompositeLibraryName");
+		assertEquals(1, ls.length);
+		ITagLibrary l = ls[0];
+		IComponent[] cs = l.getComponents();
+		assertEquals(2, cs.length);
+		IComponent c = l.getComponent("input");
+		assertNotNull(c);
+	}
+
 }


### PR DESCRIPTION
Test is added.
