### PR TITLE
JBIDE-10219 Migrate org.eclipse.core.runtime.contentTypes

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.xml.ui/plugin.xml
+++ b/seam/plugins/org.jboss.tools.seam.xml.ui/plugin.xml
@@ -36,7 +36,7 @@
 	</extension>
 
      <extension
-         point="org.eclipse.core.runtime.contentTypes">
+         point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="xml"


### PR DESCRIPTION
Migrate org.eclipse.core.runtime.contentTypes extension points to org.eclipse.core.contenttype.contentTypes
