### PR TITLE
JBIDE-15398 CDI Builder is sloooow

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
@@ -162,7 +162,27 @@ public class CDICoreNature implements IProjectNature {
 	}
 
 	public Set<CDICoreNature> getCDIProjects() {
-		return getCDIProjects(false);
+		Set<CDICoreNature> result = new HashSet<CDICoreNature>();
+		synchronized(this) {
+			result.addAll(dependsOn);
+		}
+		return result;
+	}
+
+	/**
+	 * Returns the number of projects included explicitly 
+	 * to classpath of current project that are contained in
+	 * the passed set.
+	 * 
+	 * @param projects
+	 * @return
+	 */
+	public synchronized int countDirectDependencies(Set<CDICoreNature> projects) {
+		int result = 0;
+		for (CDICoreNature r: dependsOn) {
+			if(projects.contains(r)) result++;
+		}
+		return result;
 	}
 
 	public CDIExtensionManager getExtensionManager() {
@@ -171,22 +191,23 @@ public class CDICoreNature implements IProjectNature {
 
 	/**
 	 * Returns all the project that are included into classpath of this project.
+	 * Modification to the returned set does not affect stored references.
+	 * 
 	 * @param hierarchy If false then return the projects explicitly included into the project classpath.
 	 * If true then all the project from the entire hierarchy will be returned.
 	 * @return
 	 */
 	public Set<CDICoreNature> getCDIProjects(boolean hierarchy) {
-		if(hierarchy) {
-			if(dependsOn.isEmpty()) return dependsOn;
+		if(hierarchy && dependsOnOtherProjects()) {
 			Set<CDICoreNature> result = new HashSet<CDICoreNature>();
 			getAllCDIProjects(result);
 			return result;
 		} else {
-			return dependsOn;
+			return getCDIProjects();
 		}
 	}
 
-	void getAllCDIProjects(Set<CDICoreNature> result) {
+	synchronized void getAllCDIProjects(Set<CDICoreNature> result) {
 		for (CDICoreNature n:dependsOn) {
 			if(result.contains(n)) continue;
 			result.add(n);
@@ -195,8 +216,7 @@ public class CDICoreNature implements IProjectNature {
 	}
 
 	public List<TypeDefinition> getAllTypeDefinitions() {
-		Set<CDICoreNature> ps = getCDIProjects(true);
-		if(ps == null || ps.isEmpty()) {
+		if(!dependsOnOtherProjects()) {
 			return getDefinitions().getTypeDefinitions();
 		}
 		List<TypeDefinition> ds = getDefinitions().getTypeDefinitions();
@@ -206,7 +226,7 @@ public class CDICoreNature implements IProjectNature {
 		for (TypeDefinition d: ds) {
 			keys.add(d.getKey());
 		}
-		for (CDICoreNature p: ps) {
+		for (CDICoreNature p: getCDIProjects(true)) {
 			List<TypeDefinition> ds2 = p.getDefinitions().getTypeDefinitions();
 			for (TypeDefinition d: ds2) {
 				String key = d.getKey();
@@ -219,34 +239,12 @@ public class CDICoreNature implements IProjectNature {
 		return result;
 	}
 
+	public synchronized boolean dependsOnOtherProjects() {
+		return !dependsOn.isEmpty();
+	}
+
 	public List<AnnotationDefinition> getAllAnnotations() {
-		Set<CDICoreNature> ps = getCDIProjects(false);
-		if(ps == null || ps.isEmpty() || getCDIProjects(true).contains(this)) {
-			return getDefinitions().getAllAnnotations();
-		}
-		List<AnnotationDefinition> result = new ArrayList<AnnotationDefinition>();
-		Set<IType> types = new HashSet<IType>();
-		for (CDICoreNature p: ps) {
-			List<AnnotationDefinition> ds2 = p.getAllAnnotations();
-			for (AnnotationDefinition d: ds2) {
-				IType t = d.getType();
-				if(t != null && !types.contains(t)) {
-					types.add(t);
-					result.add(d);
-				}
-			}
-		}
-
-		List<AnnotationDefinition> ds = getDefinitions().getAllAnnotations();
-		for (AnnotationDefinition d: ds) {
-			IType t = d.getType();
-			if(t != null && !types.contains(t)) {
-				types.add(t);
-				result.add(d);
-			}
-		}
-
-		return result;
+		return getDefinitions().getAllAnnotationsWithDependencies();
 	}
 
 	/**
@@ -259,16 +257,14 @@ public class CDICoreNature implements IProjectNature {
 	public Set<String> getAllVetoedTypes() {
 		Set<String> result = new HashSet<String>();
 		result.addAll(definitions.getVetoedTypes());
-		Set<CDICoreNature> ps = getCDIProjects(true);
-		for (CDICoreNature n: ps) {
+		for (CDICoreNature n: getCDIProjects(true)) {
 			result.addAll(n.getDefinitions().getVetoedTypes());
 		}		
 		return result;
 	}
 
 	public Set<BeansXMLDefinition> getAllBeanXMLDefinitions() {
-		Set<CDICoreNature> ps = getCDIProjects(true);
-		if(ps == null || ps.isEmpty()) {
+		if(!dependsOnOtherProjects()) {
 			return getDefinitions().getBeansXMLDefinitions();
 		}
 		Set<BeansXMLDefinition> ds = getDefinitions().getBeansXMLDefinitions();
@@ -279,7 +275,7 @@ public class CDICoreNature implements IProjectNature {
 			IPath t = d.getPath();
 			if(t != null) paths.add(t);
 		}
-		for (CDICoreNature p: ps) {
+		for (CDICoreNature p: getCDIProjects(true)) {
 			Set<BeansXMLDefinition> ds2 = p.getDefinitions().getBeansXMLDefinitions();
 			for (BeansXMLDefinition d: ds2) {
 				IPath t = d.getPath();
@@ -339,11 +335,15 @@ public class CDICoreNature implements IProjectNature {
 	}
 
 	public void addCDIProject(final CDICoreNature p) {
-		if(dependsOn.contains(p)) return;
+		synchronized(this) {
+			if(dependsOn.contains(p)) {
+				return;
+			}
+		}
 		addUsedCDIProject(p);
 		p.addDependentCDIProject(this);
 		//TODO
-		if(!p.isStorageResolved()) {
+		if(!p.isStorageResolved() && p.getProject() != null) {
 			XJob.addRunnableWithPriority(new XRunnable() {
 				public void run() {
 					p.resolve();
@@ -359,22 +359,18 @@ public class CDICoreNature implements IProjectNature {
 		}
 	}
 
-	public void removeCDIProject(CDICoreNature p) {
+	public synchronized void removeCDIProject(CDICoreNature p) {
 		if(!dependsOn.contains(p)) return;
 		p.usedBy.remove(this);
-		synchronized (dependsOn) {
-			dependsOn.remove(p);
-		}
+		dependsOn.remove(p);
 		//TODO
 	}
 
-	void addUsedCDIProject(CDICoreNature p) {
-		synchronized (dependsOn) {
-			dependsOn.add(p);
-		}
+	synchronized void addUsedCDIProject(CDICoreNature p) {
+		dependsOn.add(p);
 	}
 
-	public void addDependentCDIProject(CDICoreNature p) {
+	public synchronized void addDependentCDIProject(CDICoreNature p) {
 		usedBy.add(p);
 	}
 
@@ -606,9 +602,9 @@ public class CDICoreNature implements IProjectNature {
 	 * Test method.
 	 */
 	public void reloadProjectDependencies() {
-		dependsOn.clear();
-		usedBy.clear();
 		synchronized (this) {
+			dependsOn.clear();
+			usedBy.clear();
 			projectDependenciesLoaded = false;
 		}
 		loadProjectDependenciesFromKBProject();
@@ -658,7 +654,7 @@ public class CDICoreNature implements IProjectNature {
 		}
 	}
 
-	public void dispose() {
+	public synchronized void dispose() {
 		CDICoreNature[] ds = dependsOn.toArray(new CDICoreNature[dependsOn.size()]);
 		for (CDICoreNature d: ds) {
 			removeCDIProject(d);

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
@@ -13,6 +13,9 @@ package org.jboss.tools.cdi.core.test;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import junit.framework.TestCase;
 
@@ -39,6 +42,7 @@ import org.jboss.tools.cdi.core.IProducerMethod;
 import org.jboss.tools.cdi.core.IQualifier;
 import org.jboss.tools.cdi.core.IScope;
 import org.jboss.tools.cdi.internal.core.impl.ProducerMethod;
+import org.jboss.tools.cdi.internal.core.impl.definition.DefinitionContext;
 import org.jboss.tools.common.java.IAnnotationDeclaration;
 import org.jboss.tools.jst.web.kb.IKbProject;
 import org.jboss.tools.jst.web.kb.KbProjectFactory;
@@ -121,6 +125,8 @@ public class DependentProjectTest extends TestCase {
 		scope = producer.getScope();
 		ns = scope.getAnnotationDeclaration(CDIConstants.NORMAL_SCOPE_ANNOTATION_TYPE_NAME);
 		sd = scope.getAnnotationDeclaration(CDIConstants.SCOPE_ANNOTATION_TYPE_NAME);
+		
+		ICDIProject cdi2 = CDICorePlugin.getCDIProject(project2, true);
 		assertNull(ns);
 		assertNotNull(sd);
 	}
@@ -449,4 +455,119 @@ public class DependentProjectTest extends TestCase {
 		fail("Can't find \"" + fieldName + "\" injection point filed in " + beanClassFilePath);
 		return null;
 	}
+
+	private CDICoreNature[] createArray(int length) {
+		//create projects
+		CDICoreNature[] natures = new CDICoreNature[length];
+		for (int i = 0; i < natures.length; i++) {
+			natures[i] = new CDICoreNature();
+		}
+		//shuffle to exclude influence of the order in which objects are created.
+		shuffle(natures);
+		return natures;
+	}
+
+	Random seed = new Random();
+
+	private void shuffle(Object[] os) {
+		for (int i = 0; i < os.length; i++) {
+			int j = seed.nextInt(os.length - i) + i;
+			Object n = os[i];
+			os[i] = os[j];
+			os[j] = n;
+		}
+	}
+
+	public void testOrderedListOfDependencies() {
+		int numberOfProjects = 5000;
+		int beginOfLoop = 1000;
+		int endOfLoop = 1010;
+
+		//create projects
+		CDICoreNature[] natures = createArray(numberOfProjects);
+
+		//Add dependencies
+		for (int k = 1; k < 15; k++) {
+			for (int i = 0; i < natures.length - k; i++) {
+				natures[i].addCDIProject(natures[i + k]);
+			}
+		}
+		//Add a looping dependency
+		natures[endOfLoop].addCDIProject(natures[beginOfLoop]);
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Looped Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		for (int i = 1; i < natures.length; i++) {
+			int index = list.indexOf(natures[i]);
+			if(i < beginOfLoop || i > endOfLoop) {
+				assertEquals(natures.length - 1, index + i);
+			}
+		}
+	}
+
+	public void testOrderedListOfDependenciesWithFactorialTree() {
+		int numberOfProjects = 3000;
+		//create projects
+		CDICoreNature[] natures = createArray(numberOfProjects);
+
+		//Add dependencies
+		for (int i = 0; i < natures.length - 1; i++) {
+			for (int j = i + 1; j < natures.length; j++) {
+				natures[i].addCDIProject(natures[j]);
+			}
+		}
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Factorial Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		checkOrder(natures, list);
+	}
+
+	void checkOrder(CDICoreNature[] natures, List<CDICoreNature> list) {
+		for (int i = 1; i < natures.length; i++) {
+			int index = list.indexOf(natures[i]);
+			for (CDICoreNature n: natures[i].getCDIProjects()) {
+				int index1 = list.indexOf(n);
+				assertTrue(index1 < index);				
+			}
+		}
+	}
+
+	public void testOrderedListOfDependenciesWithModerateTree() {
+		Random seed = new Random();
+		int[] levels = new int[]{0,1,3,7,15,31,63,127,200,300,400,500,600,700,800,900,950,960,970,980,990,1000,1010,1020,1030};
+		int numberOfProjects = levels[levels.length - 1];
+		CDICoreNature[] natures = createArray(numberOfProjects);
+		
+		for (int i = 0; i < levels.length - 2; i++) {
+			for (int p1 = levels[i]; p1 < levels[i + 1]; p1++) {
+				int p2 = levels[i + 1] + seed.nextInt(levels[i + 2] - levels[i + 1]);
+				natures[p1].addCDIProject(natures[p2]);
+			}
+			for (int p2 = levels[i + 1]; p2 < levels[i + 2]; p2++) {
+				int p1 = levels[i] + seed.nextInt(levels[i + 1] - levels[i]);
+				natures[p1].addCDIProject(natures[p2]);
+			}
+			
+		}
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Moderate Tree Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		checkOrder(natures, list);
+	}
+
 }


### PR DESCRIPTION
Methods CDICoreNature.getAllAnnotations() and
DefinitionContext.getAnnotation(String)
are optimazed in case of many dependencies in workspace.

Existing tests for dependent projects must pass.
