### PR TITLE
JBIDE-15398 CDI Builder is sloooow

### DIFF
--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
@@ -13,6 +13,9 @@ package org.jboss.tools.cdi.core.test;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import junit.framework.TestCase;
 
@@ -39,6 +42,7 @@ import org.jboss.tools.cdi.core.IProducerMethod;
 import org.jboss.tools.cdi.core.IQualifier;
 import org.jboss.tools.cdi.core.IScope;
 import org.jboss.tools.cdi.internal.core.impl.ProducerMethod;
+import org.jboss.tools.cdi.internal.core.impl.definition.DefinitionContext;
 import org.jboss.tools.common.java.IAnnotationDeclaration;
 import org.jboss.tools.jst.web.kb.IKbProject;
 import org.jboss.tools.jst.web.kb.KbProjectFactory;
@@ -121,6 +125,8 @@ public class DependentProjectTest extends TestCase {
 		scope = producer.getScope();
 		ns = scope.getAnnotationDeclaration(CDIConstants.NORMAL_SCOPE_ANNOTATION_TYPE_NAME);
 		sd = scope.getAnnotationDeclaration(CDIConstants.SCOPE_ANNOTATION_TYPE_NAME);
+		
+		ICDIProject cdi2 = CDICorePlugin.getCDIProject(project2, true);
 		assertNull(ns);
 		assertNotNull(sd);
 	}
@@ -449,4 +455,119 @@ public class DependentProjectTest extends TestCase {
 		fail("Can't find \"" + fieldName + "\" injection point filed in " + beanClassFilePath);
 		return null;
 	}
+
+	private CDICoreNature[] createArray(int length) {
+		//create projects
+		CDICoreNature[] natures = new CDICoreNature[length];
+		for (int i = 0; i < natures.length; i++) {
+			natures[i] = new CDICoreNature();
+		}
+		//shuffle to exclude influence of the order in which objects are created.
+		shuffle(natures);
+		return natures;
+	}
+
+	Random seed = new Random();
+
+	private void shuffle(Object[] os) {
+		for (int i = 0; i < os.length; i++) {
+			int j = seed.nextInt(os.length - i) + i;
+			Object n = os[i];
+			os[i] = os[j];
+			os[j] = n;
+		}
+	}
+
+	public void testOrderedListOfDependencies() {
+		int numberOfProjects = 5000;
+		int beginOfLoop = 1000;
+		int endOfLoop = 1010;
+
+		//create projects
+		CDICoreNature[] natures = createArray(numberOfProjects);
+
+		//Add dependencies
+		for (int k = 1; k < 15; k++) {
+			for (int i = 0; i < natures.length - k; i++) {
+				natures[i].addCDIProject(natures[i + k]);
+			}
+		}
+		//Add a looping dependency
+		natures[endOfLoop].addCDIProject(natures[beginOfLoop]);
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Looped Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		for (int i = 1; i < natures.length; i++) {
+			int index = list.indexOf(natures[i]);
+			if(i < beginOfLoop || i > endOfLoop) {
+				assertEquals(natures.length - 1, index + i);
+			}
+		}
+	}
+
+	public void testOrderedListOfDependenciesWithFactorialTree() {
+		int numberOfProjects = 3000;
+		//create projects
+		CDICoreNature[] natures = createArray(numberOfProjects);
+
+		//Add dependencies
+		for (int i = 0; i < natures.length - 1; i++) {
+			for (int j = i + 1; j < natures.length; j++) {
+				natures[i].addCDIProject(natures[j]);
+			}
+		}
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Factorial Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		checkOrder(natures, list);
+	}
+
+	void checkOrder(CDICoreNature[] natures, List<CDICoreNature> list) {
+		for (int i = 1; i < natures.length; i++) {
+			int index = list.indexOf(natures[i]);
+			for (CDICoreNature n: natures[i].getCDIProjects()) {
+				int index1 = list.indexOf(n);
+				assertTrue(index1 < index);				
+			}
+		}
+	}
+
+	public void testOrderedListOfDependenciesWithModerateTree() {
+		Random seed = new Random();
+		int[] levels = new int[]{0,1,3,7,15,31,63,127,200,300,400,500,600,700,800,900,950,960,970,980,990,1000,1010,1020,1030};
+		int numberOfProjects = levels[levels.length - 1];
+		CDICoreNature[] natures = createArray(numberOfProjects);
+		
+		for (int i = 0; i < levels.length - 2; i++) {
+			for (int p1 = levels[i]; p1 < levels[i + 1]; p1++) {
+				int p2 = levels[i + 1] + seed.nextInt(levels[i + 2] - levels[i + 1]);
+				natures[p1].addCDIProject(natures[p2]);
+			}
+			for (int p2 = levels[i + 1]; p2 < levels[i + 2]; p2++) {
+				int p1 = levels[i] + seed.nextInt(levels[i + 1] - levels[i]);
+				natures[p1].addCDIProject(natures[p2]);
+			}
+			
+		}
+
+		long t = System.currentTimeMillis();
+		Set<CDICoreNature> set = natures[0].getCDIProjects(true);
+		List<CDICoreNature> list = DefinitionContext.toListOrderedByDependencies(set);
+		long dt = System.currentTimeMillis() - t;
+		System.out.println("Ordered List Of Moderate Tree Dependencies of " + numberOfProjects + " projects in " + dt + "ms.");
+
+		assertEquals(-1, list.indexOf(natures[0]));
+		checkOrder(natures, list);
+	}
+
 }


### PR DESCRIPTION
Methods CDICoreNature.getAllAnnotations() and
DefinitionContext.getAnnotation(String)
are optimazed in case of many dependencies in workspace.

Existing tests for dependent projects must pass.
