### PR TITLE
JBIDE-15385 Support annotation @Priority

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDIConstants.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDIConstants.java
@@ -29,6 +29,7 @@ public interface CDIConstants {
 	public String NEW_QUALIFIER_TYPE_NAME = "javax.enterprise.inject.New";
 
 	public String VETOED_ANNOTATION_TYPE_NAME = "javax.enterprise.inject.Vetoed";
+	public String PRIORITY_ANNOTATION_TYPE_NAME = "javax.annotation.Priority";
 
 	public String STEREOTYPE_ANNOTATION_TYPE_NAME = "javax.enterprise.inject.Stereotype";
 	public String MODEL_STEREOTYPE_TYPE_NAME = "javax.enterprise.inject.Model";

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/IClassBean.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/IClassBean.java
@@ -88,4 +88,11 @@ public interface IClassBean extends IBean, IInterceptorBinded, IJavaReference {
 	 * @return
 	 */
 	Collection<IInjectionPoint> getInjectionPoints(boolean all);
+
+	/**
+	 * Returns value of annotation @Priority(int) if it is present for CDI 1.1.
+	 * Otherwise, returns null.
+	 * @return
+	 */
+	Integer getPriority();
 }

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/ClassBean.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/ClassBean.java
@@ -436,6 +436,9 @@ public class ClassBean extends AbstractBeanElement implements IClassBean {
 			return false;
 		}
 		if(isAlternative()) {
+			if(getAnnotation(CDIConstants.PRIORITY_ANNOTATION_TYPE_NAME) != null) {
+				return true;
+			}
 			if(getCDIProject().isClassAlternativeActivated(getDefinition().getQualifiedName())) {
 				return true;
 			}
@@ -568,8 +571,13 @@ public class ClassBean extends AbstractBeanElement implements IClassBean {
 	 * @see org.jboss.tools.cdi.core.IBean#isSelectedAlternative()
 	 */
 	public boolean isSelectedAlternative() {
-		if(getDefinition().getAlternativeAnnotation() != null && getCDIProject().isTypeAlternative(getBeanClass().getFullyQualifiedName())) {
-			return true;
+		if(getDefinition().getAlternativeAnnotation() != null) {
+			if(getCDIProject().isTypeAlternative(getBeanClass().getFullyQualifiedName())) {
+				return true;
+			}
+			if(getAnnotation(CDIConstants.PRIORITY_ANNOTATION_TYPE_NAME) != null) {
+				return true;
+			}
 		}
 		for (IStereotypeDeclaration d: getStereotypeDeclarations(true)) {
 			IStereotype s = d.getStereotype();
@@ -636,5 +644,20 @@ public class ClassBean extends AbstractBeanElement implements IClassBean {
 		for (BeanField f: fields) {
 			f.setField(f.getField()); // type update
 		}
+	}
+
+	@Override
+	public Integer getPriority() {
+		IAnnotationDeclaration d = getAnnotation(CDIConstants.PRIORITY_ANNOTATION_TYPE_NAME);
+		if(d instanceof AnnotationDeclaration) {
+			Object o = ((AnnotationDeclaration)d).getMemberConstantValue(null);
+			if(o == null) {
+				o = d.getMemberValue(null);
+			}
+			if(o instanceof Integer) {
+				return (Integer)o;
+			}
+		}
+		return null;
 	}
 }

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/DecoratorBean.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/DecoratorBean.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICorePlugin;
 import org.jboss.tools.cdi.core.IDecorator;
 import org.jboss.tools.common.java.IAnnotationDeclaration;
@@ -65,6 +66,7 @@ public class DecoratorBean extends ClassBean implements IDecorator {
 	 */
 	@Override
 	public boolean isEnabled() {
-		return !getCDIProject().getDecoratorClasses(getBeanClass().getFullyQualifiedName()).isEmpty();
+		return !getCDIProject().getDecoratorClasses(getBeanClass().getFullyQualifiedName()).isEmpty() 
+				|| getAnnotation(CDIConstants.PRIORITY_ANNOTATION_TYPE_NAME) != null;
 	}
 }

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/InterceptorBean.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/InterceptorBean.java
@@ -10,6 +10,7 @@
  ******************************************************************************/ 
 package org.jboss.tools.cdi.internal.core.impl;
 
+import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.IInterceptor;
 import org.jboss.tools.common.java.IAnnotationDeclaration;
 
@@ -27,7 +28,8 @@ public class InterceptorBean extends ClassBean implements IInterceptor {
 	}
 
 	public boolean isEnabled() {
-		return !getCDIProject().getInterceptorClasses(getBeanClass().getFullyQualifiedName()).isEmpty();
+		return !getCDIProject().getInterceptorClasses(getBeanClass().getFullyQualifiedName()).isEmpty()
+			|| getAnnotation(CDIConstants.PRIORITY_ANNOTATION_TYPE_NAME) != null;
 	}
 
 }

--- a/cdi/tests/org.jboss.tools.cdi.core.test/pom.xml
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/pom.xml
@@ -270,11 +270,6 @@
 								<version>1.1</version>
 							</artifactItem>
 							<artifactItem>
-								<groupId>org.jboss.spec.javax.interceptor</groupId>
-								<artifactId>jboss-interceptors-api_1.1_spec</artifactId>
-								<version>1.0.0.Beta1</version>
-							</artifactItem>
-							<artifactItem>
 								<groupId>org.jboss.spec.javax.jms</groupId>
 								<artifactId>jboss-jms-api_1.1_spec</artifactId>
 								<version>1.0.0.Final</version>

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/IllegalTableFactory.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/IllegalTableFactory.java
@@ -1,0 +1,19 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+
+@Alternative
+@ApplicationScoped
+public class IllegalTableFactory {
+	
+	@Produces @TableQualifier(0)
+	MarbleTable modelY = new MarbleTable();
+	
+	@Produces @TableQualifier(1)
+	MarbleTable modelA = new MarbleTable();
+	
+	@Produces @TableQualifier(2)
+	MarbleTable modelB = new MarbleTable();
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/IronTable.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/IronTable.java
@@ -1,0 +1,13 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.annotation.Priority;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@ApplicationScoped
+@Alternative
+@Priority(APPLICATION + 100)
+public class IronTable {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/LuxuryTableFactory.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/LuxuryTableFactory.java
@@ -1,0 +1,21 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+package test.a;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@Alternative
+@ApplicationScoped
+@Priority(APPLICATION + 100)
+public class LuxuryTableFactory {
+	
+	@Produces @TableQualifier(1)
+	MarbleTable modelA = new MarbleTable();
+	
+	@Produces @TableQualifier(2)
+	MarbleTable modelB = new MarbleTable();
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/MarbleTable.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/MarbleTable.java
@@ -1,0 +1,13 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.annotation.Priority;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@ApplicationScoped
+@Alternative
+@Priority(APPLICATION)
+public class MarbleTable {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/Office.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/Office.java
@@ -1,0 +1,33 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Office {
+
+	/**
+	 * Eligible beans with priorities 2000, 2001, 2100
+	 * Resolved to bean with maximum priority.
+	 */
+	@Inject MarbleTable marbleTable;
+
+	/**
+	 * Assignable non-eligible bean without priority.
+	 * Eligible bean with priority.
+	 * Resolved.
+	 */
+	@Inject @TableQualifier(0) MarbleTable marbleTableY;
+
+	/**
+	 * Eligible beans with priorities 2001, 2100
+	 * Resolved to bean with maximum priority.
+	 */
+	@Inject @TableQualifier(1) MarbleTable marbleTableA;  
+
+	/**
+	 * Eligible beans with priorities 2001, 2100, 2100
+	 * Ambiguous dependency.
+	 */
+	@Inject @TableQualifier(2) MarbleTable marbleTableB;  
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/RivalLuxuryTableFactory.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/RivalLuxuryTableFactory.java
@@ -1,0 +1,17 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@Alternative
+@ApplicationScoped
+@Priority(APPLICATION + 100)
+public class RivalLuxuryTableFactory {
+	
+	@Produces @TableQualifier(2)
+	MarbleTable modelB = new MarbleTable();
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/StrawTable.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/StrawTable.java
@@ -1,0 +1,13 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.annotation.Priority;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@ApplicationScoped
+@Alternative
+@Priority(APPLICATION)
+public class StrawTable {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/TableFactory.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/TableFactory.java
@@ -1,0 +1,25 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+@Alternative
+@ApplicationScoped
+@Priority(APPLICATION + 1)
+public class TableFactory {
+	
+	@Produces MarbleTable modelX = new MarbleTable();
+	
+	@Produces @TableQualifier(0)
+	MarbleTable modelY = new MarbleTable();
+
+	@Produces @TableQualifier(1)
+	MarbleTable modelA = new MarbleTable();
+	
+	@Produces @TableQualifier(2)
+	MarbleTable modelB = new MarbleTable();
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/TableQualifier.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/TableQualifier.java
@@ -1,0 +1,21 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+public @interface TableQualifier {
+	int value();
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/WoodenTable.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/WoodenTable.java
@@ -1,0 +1,11 @@
+package org.jboss.jsr299.tck.tests.jbt.resolution.priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.annotation.Priority;
+
+@ApplicationScoped
+@Alternative
+@Priority(300)
+public class WoodenTable {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
@@ -97,6 +97,7 @@ import org.jboss.tools.cdi.core.test.tck11.InterceptorDefinitionCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.NameDefinitionCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.NamedBeanRefactoringCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.ObserverMethodResolutionCDI11Test;
+import org.jboss.tools.cdi.core.test.tck11.PriorityCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.ProducerMethodDefinitionCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.QualifierDefinitionCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.QualifierWithMembersCDI11Test;
@@ -307,6 +308,7 @@ public class CDICoreAllTests {
 		suite.addTestSuite(CDIUtilCDI11Test.class);
 		suite.addTestSuite(CoreCDI11Test.class);
 		suite.addTestSuite(ResourceExclusionCDI11Test.class);
+		suite.addTestSuite(PriorityCDI11Test.class);
 
 		// Marker validation tests
 		suite.addTestSuite(DefenitionErrorsValidationCDI11Test.class);

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/PriorityCDI11Test.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/PriorityCDI11Test.java
@@ -1,0 +1,122 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.cdi.core.test.tck11;
+
+import java.util.Collection;
+
+import org.eclipse.core.runtime.CoreException;
+import org.jboss.tools.cdi.core.IBean;
+import org.jboss.tools.cdi.core.IClassBean;
+import org.jboss.tools.cdi.core.IInjectionPointField;
+
+/**
+ * @author Viacheslav Kabanovich
+ */
+public class PriorityCDI11Test extends TCK11Test {
+
+	public PriorityCDI11Test() {}
+
+	/**
+	 * Priority(300)
+	 */
+	public void testSimplePriorityValue() throws CoreException {
+		Collection<IBean> bs = getBeans("org.jboss.jsr299.tck.tests.jbt.resolution.priority.WoodenTable");
+		assertEquals(1, bs.size());
+		IBean b = bs.iterator().next();
+		assertTrue(b instanceof IClassBean);
+		IClassBean cb = (IClassBean)b;
+		assertTrue(cb.isSelectedAlternative());
+		assertTrue(cb.isEnabled());
+		Integer priority = cb.getPriority();
+		assertNotNull(priority);
+		assertEquals(300, priority.intValue());
+	}
+
+	/**
+	 * Priority(APPLICATION)
+	 */
+	public void testReferencedConstantPriorityValue() throws CoreException {
+		Collection<IBean> bs = getBeans("org.jboss.jsr299.tck.tests.jbt.resolution.priority.StrawTable");
+		assertEquals(1, bs.size());
+		IBean b = bs.iterator().next();
+		assertTrue(b instanceof IClassBean);
+		IClassBean cb = (IClassBean)b;
+		assertTrue(cb.isSelectedAlternative());
+		assertTrue(cb.isEnabled());
+		Integer priority = cb.getPriority();
+		assertNotNull(priority);
+		assertEquals(2000, priority.intValue());
+	}
+
+	/**
+	 * Priority(APPLICATION + 100)
+	 */
+	public void testExpressionPriorityValue() throws CoreException {
+		Collection<IBean> bs = getBeans("org.jboss.jsr299.tck.tests.jbt.resolution.priority.IronTable");
+		assertEquals(1, bs.size());
+		IBean b = bs.iterator().next();
+		assertTrue(b instanceof IClassBean);
+		IClassBean cb = (IClassBean)b;
+		assertTrue(cb.isSelectedAlternative());
+		assertTrue(cb.isEnabled());
+		Integer priority = cb.getPriority();
+		assertNotNull(priority);
+		assertEquals(2100, priority.intValue());
+	}
+
+	static String OFFICE_PATH = "JavaSource/org/jboss/jsr299/tck/tests/jbt/resolution/priority/Office.java";
+
+	/**
+	 * Eligible beans with priorities 2000, 2001, 2100.
+	 * Resolved to bean with maximum priority.
+	 */
+	public void testResolutionWithSingleMaxPriorityValue() throws CoreException {
+		IInjectionPointField f = getInjectionPointField(OFFICE_PATH, "marbleTable");
+		assertNotNull(f);
+		Collection<IBean> beans = cdiProject.getBeans(true, f);
+		assertEquals(1, beans.size());
+	}
+
+	/**
+	 * Eligible beans with priorities 2001, 2100 and qualifier.
+	 * Resolved to bean with maximum priority.
+	 */
+	public void testResolutionWithSingleMaxPriorityValueAndQualifier() throws CoreException {
+		IInjectionPointField f = getInjectionPointField(OFFICE_PATH, "marbleTableA");
+		assertNotNull(f);
+		Collection<IBean> beans = cdiProject.getBeans(true, f);
+		assertEquals(1, beans.size());
+	}
+
+	/**
+	 * Assignable non-eligible (unselected) bean without priority.
+	 * Eligible bean with priority.
+	 * Resolved to bean with priority.
+	 */
+	public void testResolutionWithAssignableBeanWithoutPriority() throws CoreException {
+		IInjectionPointField f = getInjectionPointField(OFFICE_PATH, "marbleTableY");
+		assertNotNull(f);
+		Collection<IBean> beans = cdiProject.getBeans(true, f);
+		assertEquals(1, beans.size());
+	}
+
+	/**
+	 * Eligible beans with priorities 2001, 2100, 2100.
+	 * Ambiguous dependency.
+	 */
+	public void testResolutionWithMultipleMaxPriorityValue() throws CoreException {
+		IInjectionPointField f = getInjectionPointField(OFFICE_PATH, "marbleTableB");
+		assertNotNull(f);
+		Collection<IBean> beans = cdiProject.getBeans(true, f);
+		assertEquals(2, beans.size());
+	}
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/testmodel/CDIBean.java
+++ b/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/testmodel/CDIBean.java
@@ -301,4 +301,10 @@ public class CDIBean extends CDIElement implements IClassBean{
 		// TODO Auto-generated method stub
 		return 0;
 	}
+
+	@Override
+	public Integer getPriority() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }


### PR DESCRIPTION
Annotation @Priority is used to determine bean enablement
and to resolve ambiguous dependencies. Test is added.
