### PR TITLE
JBIDE-15518 Add to CDI model extensions provided without extension service

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/schema/cdiextensions.exsd
+++ b/cdi/plugins/org.jboss.tools.cdi.core/schema/cdiextensions.exsd
@@ -66,6 +66,16 @@
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="recognizer" type="string">
+            <annotation>
+               <documentation>
+                  Fully qualified name of implementation of IExtensionRecognizer that is called for runtime that is not expected to be registered in /META-INF/services/javax.enterprise.inject.spi.Extension
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.jboss.tools.cdi.core.extension.IExtensionRecognizer"/>
+               </appInfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/extension/DefaultExtensionRecognizer.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/extension/DefaultExtensionRecognizer.java
@@ -1,0 +1,38 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdi.core.extension;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.common.util.EclipseJavaUtil;
+
+/**
+ * Default implementation just checks that class represented by 'runtime'
+ * exists in the classpath of Java project.
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class DefaultExtensionRecognizer implements IExtensionRecognizer {
+
+	@Override
+	public boolean containsExtension(String runtime, IJavaProject javaProject) {
+		try {
+			IType type = EclipseJavaUtil.findType(javaProject, runtime);
+			return type != null && type.exists();
+		} catch (JavaModelException e) {
+			CDICorePlugin.getDefault().logError(e);
+			return false;
+		}
+	}
+}

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/extension/IExtensionRecognizer.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/extension/IExtensionRecognizer.java
@@ -1,0 +1,33 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdi.core.extension;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+/**
+ * Normally, CDI extension given by 'runtime' is registered in
+ * META-INF/services/javax.enterprise.inject.spi.Extension
+ * However, CDI or server implementations may prefer adding 
+ * their system extensions directly.
+ * 
+ * To include such extensions into CDI model, 'runtime' should be 
+ * added to extension point org.jboss.tools.cdi.core.cdiextensions
+ * with attribute 'recognizer' set to implementation of this interface.
+ * Default implementation just checks that class represented by 'runtime'
+ * exists in the classpath of Java project.
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public interface IExtensionRecognizer {
+
+	public boolean containsExtension(String runtime, IJavaProject javaProject); 
+}

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/scanner/lib/ClassPathMonitor.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/scanner/lib/ClassPathMonitor.java
@@ -30,9 +30,9 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.extension.CDIExtensionFactory;
 import org.jboss.tools.common.model.XModelObject;
 import org.jboss.tools.common.model.filesystems.FileSystemsHelper;
 import org.jboss.tools.common.model.filesystems.impl.FileAnyImpl;
@@ -41,6 +41,14 @@ import org.jboss.tools.common.model.project.ext.AbstractClassPathMonitor;
 import org.jboss.tools.common.model.util.EclipseResourceUtil;
 
 public class ClassPathMonitor extends AbstractClassPathMonitor<CDICoreNature>{
+	/**
+	 * Runtimes detected in jars are stored in CDIExtensionManager by jar path 
+	 * in order to replace them when jar is modified.
+	 * Runtimes detected with recognizers are not bound to jars so that they
+	 * are stored in CDIExtensionManager by a unique key.
+	 */
+	private static final String RECOGNIZED_RUNTIMES_PATH = "_recognized_";
+
 	IPath[] srcs = new IPath[0];
 
 	Map<FileAnyImpl, Long> servicesInSrc = new HashMap<FileAnyImpl, Long>();
@@ -104,6 +112,11 @@ public class ClassPathMonitor extends AbstractClassPathMonitor<CDICoreNature>{
 				if(nrd) newRuntimeDetected = true;
 			}
 		}
+
+		IJavaProject javaProject = EclipseResourceUtil.getJavaProject(project.getProject());
+		Set<String> recognizedRuntimes = CDIExtensionFactory.getInstance().getRecognizedRuntimes(javaProject);
+		boolean nrd = project.getExtensionManager().setRuntimes(RECOGNIZED_RUNTIMES_PATH, recognizedRuntimes);
+		if(nrd) newRuntimeDetected = true;
 		
 		if(newRuntimeDetected) {
 			for (String p: processed) {

--- a/cdi/tests/org.jboss.tools.cdi.core.test/plugin.xml
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/plugin.xml
@@ -8,6 +8,11 @@
 	          runtime="org.jboss.tools.cdi.core.fake.FakeExtension">
 	    </cdiextension>
 	    <cdiextension
+	          class="org.jboss.tools.cdi.core.test.extension.CDISystemExtensionImpl"
+	          recognizer="org.jboss.tools.cdi.core.extension.DefaultExtensionRecognizer"
+	          runtime="cdi.test.extension.MyExtension">
+	    </cdiextension>
+	    <cdiextension
 	          class="org.jboss.tools.cdi.core.test.tck.validation.extension.ExcludeExtension"
 	          runtime="org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.packageinfo.zoo.ExcludeExtension">
 	    </cdiextension>

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyBeanClient.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyBeanClient.java
@@ -1,0 +1,7 @@
+package cdi.test.extension;
+
+import javax.inject.Inject;
+
+public class MyBeanClient {
+	@Inject MyBeanInterface f;
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyBeanInterface.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyBeanInterface.java
@@ -1,0 +1,5 @@
+package cdi.test.extension;
+
+public interface MyBeanInterface {
+	
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyExtension.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest1/src/cdi/test/extension/MyExtension.java
@@ -1,0 +1,9 @@
+package cdi.test.extension;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.enterprise.inject.spi.Extension;
+
+public class MyExtension implements Extension {
+	
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest2/src/cdi/test/extension/MyBeanClient2.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/CDITest2/src/cdi/test/extension/MyBeanClient2.java
@@ -1,0 +1,8 @@
+package cdi.test.extension;
+
+import javax.inject.Inject;
+import cdi.test.extension.MyBeanInterface;
+
+public class MyBeanClient2 {
+	@Inject MyBeanInterface f;
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
@@ -20,6 +20,7 @@ import org.jboss.tools.cdi.core.test.ca.BeansXmlCATest;
 import org.jboss.tools.cdi.core.test.extension.ExtensionFactoryTest;
 import org.jboss.tools.cdi.core.test.extension.ExtensionManagerTest;
 import org.jboss.tools.cdi.core.test.extension.ExtensionsInSrsAndUsedProjectTest;
+import org.jboss.tools.cdi.core.test.extension.SystemExtensionTest;
 import org.jboss.tools.cdi.core.test.project.EnableCDISupportForJarTest;
 import org.jboss.tools.cdi.core.test.project.EnableCDISupportForWarTest;
 import org.jboss.tools.cdi.core.test.tck.AssignabilityOfRawAndParameterizedTypesTest;
@@ -229,6 +230,7 @@ public class CDICoreAllTests {
 		TestSuite dependentSuite = new TestSuite("Dependent Projects Tests");
 		dependentSuite.addTestSuite(DependentProjectTest.class);
 		dependentSuite.addTestSuite(ExtensionsInSrsAndUsedProjectTest.class);
+		dependentSuite.addTestSuite(SystemExtensionTest.class);
 		DependentProjectsTestSetup dependent = new DependentProjectsTestSetup(dependentSuite);
 		suiteAll.addTest(dependent);
 		suiteAll.addTestSuite(EnableCDISupportForWarTest.class);

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/DependentProjectTest.java
@@ -620,6 +620,8 @@ public class DependentProjectTest extends TestCase {
 		} finally {
 			//Restore project CDITest1 and build for other tests.
 			project1.open(null);
+			JobUtils.waitForIdle();
+			project1.build(IncrementalProjectBuilder.CLEAN_BUILD, null);
 			project1.build(IncrementalProjectBuilder.FULL_BUILD, null);
 			project2.build(IncrementalProjectBuilder.FULL_BUILD, null);
 			project3.build(IncrementalProjectBuilder.FULL_BUILD, null);

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/extension/CDISystemExtensionImpl.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/extension/CDISystemExtensionImpl.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.core.test.extension;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.jboss.tools.cdi.core.extension.AbstractDefinitionContextExtension;
+import org.jboss.tools.cdi.core.extension.ICDIExtension;
+import org.jboss.tools.cdi.core.extension.IDefinitionContextExtension;
+import org.jboss.tools.cdi.core.extension.feature.IBuildParticipantFeature;
+import org.jboss.tools.cdi.internal.core.impl.CDIProject;
+import org.jboss.tools.cdi.internal.core.impl.definition.DefinitionContext;
+import org.jboss.tools.cdi.internal.core.impl.definition.TypeDefinition;
+import org.jboss.tools.cdi.internal.core.scanner.FileSet;
+import org.jboss.tools.common.model.XModelObject;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class CDISystemExtensionImpl implements ICDIExtension, IBuildParticipantFeature {
+	SystemContext systemContext = new SystemContext();
+
+	public CDISystemExtensionImpl() {}
+
+	@Override
+	public IDefinitionContextExtension getContext() {
+		return systemContext;
+	}
+
+	@Override
+	public void beginVisiting() {
+	}
+
+	@Override
+	public void visitJar(IPath path, IPackageFragmentRoot root,
+			XModelObject beansXML) {
+	}
+
+	@Override
+	public void visit(IFile file, IPath src, IPath webinf) {
+	}
+
+	static final String MY_BEAN_INTERFACE = "cdi.test.extension.MyBeanInterface";
+
+	@Override
+	public void buildDefinitions() {
+		IType type = systemContext.getRootContext().getProject().getType(MY_BEAN_INTERFACE);
+		if(type != null && type.exists()) {
+			if(systemContext.myBeanDefinition == null ||
+					systemContext.myBeanDefinition.getType() != type) {
+				systemContext.myBeanPath = type.getPath();
+				systemContext.myBeanDefinition = new TypeDefinition();
+				systemContext.myBeanDefinition.setType(type, systemContext.getRootContext(), 0);
+				systemContext.myBeanDefinition.setBeanConstructor(true);
+				((DefinitionContext)systemContext.getRootContext().getWorkingCopy()).addType(type.getPath(), type.getFullyQualifiedName(), systemContext.myBeanDefinition);
+			}
+		} else {
+			if(systemContext.myBeanPath != null) {
+				systemContext.getRootContext().clean(systemContext.myBeanPath);
+				systemContext.myBeanPath = null;
+			}
+			systemContext.myBeanDefinition = null;
+		}		
+	}
+
+	@Override
+	public void buildDefinitions(FileSet fileSet) {
+	}
+
+	@Override
+	public void buildBeans(CDIProject target) {
+	}
+
+	class SystemContext extends AbstractDefinitionContextExtension {
+		IPath myBeanPath = null;
+		TypeDefinition myBeanDefinition = null;
+
+		protected SystemContext copy(boolean clean) {
+			SystemContext copy = new SystemContext();
+			copy.root = root;
+			if(!clean) {
+				copy.myBeanDefinition = myBeanDefinition;
+			}
+			return copy;
+		}
+		
+		public void clean() {
+			myBeanPath = null;
+			myBeanDefinition = null;
+		}
+
+	}
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/extension/SystemExtensionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/extension/SystemExtensionTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.core.test.extension;
+
+import java.util.Collection;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.core.IType;
+import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.IBean;
+import org.jboss.tools.cdi.core.ICDIProject;
+import org.jboss.tools.cdi.core.IClassBean;
+import org.jboss.tools.cdi.core.IInjectionPointField;
+import org.jboss.tools.cdi.core.extension.ICDIExtension;
+import org.jboss.tools.cdi.core.test.DependentProjectTest;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class SystemExtensionTest extends TestCase {
+	IProject project1 = null;
+	IProject project2 = null;
+
+	public SystemExtensionTest() {}
+
+	@Override
+	protected void setUp() throws Exception {
+		project1 = ResourcesPlugin.getWorkspace().getRoot().getProject("CDITest1");
+		project2 = ResourcesPlugin.getWorkspace().getRoot().getProject("CDITest2");
+	}
+
+	public void testSystemExtension() throws Exception {
+		ICDIProject cdi1 = CDICorePlugin.getCDIProject(project1, true);
+		ICDIExtension e = cdi1.getNature().getExtensionManager().getExtensionByRuntime("cdi.test.extension.MyExtension");
+		assertNotNull(e);
+		assertTrue(e instanceof CDISystemExtensionImpl);
+
+		ICDIProject cdi2 = CDICorePlugin.getCDIProject(project2, true);
+		e = cdi2.getNature().getExtensionManager().getExtensionByRuntime("cdi.test.extension.MyExtension");
+		assertNotNull(e);
+	}
+
+	public void testInjection() throws Exception {
+		ICDIProject cdi1 = CDICorePlugin.getCDIProject(project1, true);
+
+		IType t = cdi1.getNature().getType("cdi.test.extension.MyBeanInterface");
+		IClassBean c = cdi1.getBeanClass(t);
+		assertNotNull(c);
+
+		IInjectionPointField f = DependentProjectTest.getInjectionPointField(cdi1, "src/cdi/test/extension/MyBeanClient.java", "f");
+		assertNotNull(f);
+		Collection<IBean> bs = cdi1.getBeans(true, f);
+		assertEquals(1, bs.size());
+		assertSame(c, bs.iterator().next());
+	}
+
+	public void testInjectionInDependentProject() throws Exception {
+		ICDIProject cdi2 = CDICorePlugin.getCDIProject(project2, true);
+
+		IType t = cdi2.getNature().getType("cdi.test.extension.MyBeanInterface");
+		IClassBean c = cdi2.getBeanClass(t);
+		assertNotNull(c);
+
+		IInjectionPointField f = DependentProjectTest.getInjectionPointField(cdi2, "src/cdi/test/extension/MyBeanClient2.java", "f");
+		assertNotNull(f);
+		Collection<IBean> bs = cdi2.getBeans(true, f);
+		assertEquals(1, bs.size());
+		assertSame(c, bs.iterator().next());
+	}
+
+}


### PR DESCRIPTION
Added an optional attribute "recognizer" to extension point
org.jboss.tools.cdi.core.cdiextensions that holds qualified name
of implementation of IExtensionRecognizer that determines if
Java project containes CDI extensions that are not supposed to be
registered in META-INF/services/javax.enterprise.inject.spi.Extension.

Tests are added:
1. Check that extension is recognized.
2. Check that bean created by test extension implementation
is available for injection.
3. Check that if dependent project has the same extension as
parent project, exactly one bean is available for injection (this
should be tested for each extension implementation).
