### PR TITLE
JBIDE-15638 New CDI Bean wizard should require a scope for CDI 1.1 project

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreBuilder.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreBuilder.java
@@ -270,7 +270,7 @@ try {
 	private boolean updateBeanDiscoveryMode() {
 		int oldValue = getCDICoreNature().getBeanDiscoveryMode();
 		int newValue = BeanArchiveDetector.ALL;
-		if(getCDICoreNature().isAdvancedVersion()) {
+		if(getCDICoreNature().getVersion() != CDIVersion.CDI_1_0) {
 			newValue = getBeanDiscoveryMode(getPrimaryBeanXML());
 		}
 		getCDICoreNature().setBeanDiscoveryMode(newValue);
@@ -278,7 +278,7 @@ try {
 	}
 
 	private int getBeanDiscoveryMode(XModelObject beansXML) {
-		if(getCDICoreNature().isFirstVersion()) {
+		if(getCDICoreNature().getVersion() == CDIVersion.CDI_1_0) {
 			return BeanArchiveDetector.ALL;
 		} else if(beansXML == null) {
 			return BeanArchiveDetector.ANNOTATED;
@@ -354,7 +354,7 @@ try {
 		IJavaProject jp = EclipseResourceUtil.getJavaProject(getCDICoreNature().getProject());
 		if(jp == null) return;
 		FileSet fileSet = new FileSet();
-		fileSet.setCheckVetoed(getCDICoreNature().isAdvancedVersion());
+		fileSet.setCheckVetoed(getCDICoreNature().getVersion() != CDIVersion.CDI_1_0);
 		
 		for (String jar: newJars.getBeanModules().keySet()) {
 			Path path = new Path(jar);
@@ -495,7 +495,7 @@ try {
 		Map<IPath, PackageInfo> checkedPackages = new HashMap<IPath, PackageInfo>();
 		
 		CDIResourceVisitor() {
-			fileSet.setCheckVetoed(getCDICoreNature().isAdvancedVersion());
+			fileSet.setCheckVetoed(getCDICoreNature().getVersion() != CDIVersion.CDI_1_0);
 			webinfs = WebUtils.getWebInfPaths(getCurrentProject());
 			getJavaSourceRoots(getCurrentProject());
 		}
@@ -619,7 +619,7 @@ try {
 		}
 
 		private boolean isInVetoedPackage(IFile f) throws CoreException {
-			if(!getCDICoreNature().isAdvancedVersion()) {
+			if(getCDICoreNature().getVersion() == CDIVersion.CDI_1_0) {
 				return false;
 			}
 			IContainer c = f.getParent();

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
@@ -72,7 +72,7 @@ public class CDICoreNature implements IProjectNature {
 
 	private CDIExtensionManager extensions = new CDIExtensionManager();
 
-	private int version = CDIConstants.CDI_VERSION_1_0;
+	private CDIVersion version = CDIVersion.CDI_1_0;
 	private int beanDiscoveryMode = BeanArchiveDetector.ALL;
 	
 	public CDICoreNature() {
@@ -116,24 +116,8 @@ public class CDICoreNature implements IProjectNature {
 		updateVersion();
 	}
 
-	public int getVersion() {
+	public CDIVersion getVersion() {
 		return version;
-	}
-
-	/**
-	 * Helper method to check if version is 1.0.
-	 * @return
-	 */
-	public boolean isFirstVersion() {
-		return getVersion() == CDIConstants.CDI_VERSION_1_0;
-	}
-
-	/**
-	 * Helper method to check if version is 1.1 or higher.
-	 * @return
-	 */
-	public boolean isAdvancedVersion() {
-		return getVersion() >= CDIConstants.CDI_VERSION_1_1;
 	}
 
 	public int getBeanDiscoveryMode() {
@@ -150,7 +134,7 @@ public class CDICoreNature implements IProjectNature {
 	 * @return
 	 */
 	boolean updateVersion() {
-		int version = CDIUtil.getCDIVersion(getProject());
+		CDIVersion version = CDIUtil.getCDIVersion(getProject());
 		boolean changed = version != this.version;
 		this.version = version;
 		return changed;

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDIUtil.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDIUtil.java
@@ -1299,35 +1299,34 @@ public class CDIUtil {
 	}
 
 	/**
-	 * Returns id of CDI version see 
-	 * - CDIConstants.CDI_VERSION_NONE
-	 * - CDIConstants.CDI_VERSION_1_0
-	 * - CDIConstants.CDI_VERSION_1_1
+	 * Returns null or CDI version see 
+	 * - CDIVersion.CDI_1_0;
+	 * - CDIVersion.CDI_1_1;
 	 * Implemented algorithm requests for types in the project classpath:
 	 * - If CDIConstants.VETOED_ANNOTATION_TYPE_NAME type is available, 
-	 *   version is set to CDI_VERSION_1_1,
+	 *   version is set to CDIVersion.CDI_1_1,
 	 * - else if CDIConstants.QUALIFIER_ANNOTATION_TYPE_NAME is available,
-	 *   version is set to CDI_VERSION_1_0,
+	 *   version is set to CDIVersion.CDI_1_0,
 	 * - otherwise version is undefined.
 	 * In future, the algorithm may be subjected to changes.
 	 * 
 	 * @param project
 	 * @return
 	 */
-	public static int getCDIVersion(IProject project) {
+	public static CDIVersion getCDIVersion(IProject project) {
 		IJavaProject jp = EclipseResourceUtil.getJavaProject(project);
-		if(jp == null) return CDIConstants.CDI_VERSION_NONE;
+		if(jp == null) return null;
 
 		try {
 			if(EclipseJavaUtil.findType(jp, CDIConstants.VETOED_ANNOTATION_TYPE_NAME) != null) {
-				return CDIConstants.CDI_VERSION_1_1;
+				return CDIVersion.CDI_1_1;
 			} else if(EclipseJavaUtil.findType(jp, CDIConstants.QUALIFIER_ANNOTATION_TYPE_NAME) != null) {
-				return CDIConstants.CDI_VERSION_1_0;
+				return CDIVersion.CDI_1_0;
 			}
 		} catch (JavaModelException e) {
 			CDICorePlugin.getDefault().logError(e);
 		}
-		return CDIConstants.CDI_VERSION_NONE;
+		return null;
 	}
 
 }

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/ICDIProject.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/ICDIProject.java
@@ -23,5 +23,5 @@ public interface ICDIProject extends IBeanManager {
 	public boolean isStereotypeAlternative(String qualifiedName);
 	public boolean isClassAlternativeActivated(String fullQualifiedTypeName);
 	
-	public int getVersion();
+	public CDIVersion getVersion();
 }

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.IType;
 import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.CDIVersion;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IBeanMember;
 import org.jboss.tools.cdi.core.IBeanMethod;
@@ -98,7 +99,7 @@ public class CDIProject extends CDIElement implements ICDIProject, Cloneable {
 //		dbCache = CDICorePlugin.getDefault().getDBCache();
 	}
 
-	public int getVersion() {
+	public CDIVersion getVersion() {
 		return n.getVersion();
 	}
 

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProjectAsYouType.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProjectAsYouType.java
@@ -41,6 +41,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.CDIVersion;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IBeanMethod;
 import org.jboss.tools.cdi.core.ICDIElement;
@@ -108,7 +109,7 @@ public class CDIProjectAsYouType implements ICDIProject, ICDIElement {
 		}
 	}
 
-	public int getVersion() {
+	public CDIVersion getVersion() {
 		return project.getVersion();
 	}
 

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/scanner/lib/ClassPathMonitor.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/scanner/lib/ClassPathMonitor.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.CDIVersion;
 import org.jboss.tools.cdi.core.extension.CDIExtensionFactory;
 import org.jboss.tools.common.model.XModelObject;
 import org.jboss.tools.common.model.filesystems.FileSystemsHelper;
@@ -138,7 +139,7 @@ public class ClassPathMonitor extends AbstractClassPathMonitor<CDICoreNature>{
 		XModelObject b = fs.getChildByPath("META-INF/beans.xml");
 		if(b != null) {
 			newJars.getBeanModules().put(path, b);
-		} else if(project.isAdvancedVersion()) {
+		} else if(project.getVersion() != CDIVersion.CDI_1_0) {
 			int archiveType = BeanArchiveDetector.getInstance().getBeanArchive(path);
 			if(archiveType == BeanArchiveDetector.UNRESOLVED) {
 				if(!readRuntimes(fs).isEmpty()) {

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/CDIUIMessages.java
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/CDIUIMessages.java
@@ -83,6 +83,8 @@ public class CDIUIMessages extends NLS{
 	public static String MESSAGE_FIELD_NAME_EMPTY;
 	public static String MESSAGE_FIELD_NAME_NOT_VALID;
 
+	public static String SCOPE_SHOULD_BE_SET_IN_ARCHIVE_WITH_DISCOVERY_MODE_ANNOTATED;
+
 	public static String MESSAGE_INTERCEPTOR_BINDINGS_EMPTY;
 
 	public static String MESSAGE_STEREOTYPE_CANNOT_BE_APPLIED_TO_TYPE;

--- a/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/CDIUIMessages.properties
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/src/org/jboss/tools/cdi/ui/CDIUIMessages.properties
@@ -67,6 +67,8 @@ MESSAGE_METHOD_NAME_NOT_VALID=Method Name is not valid. {0}
 MESSAGE_FIELD_NAME_EMPTY=Field Name is empty.
 MESSAGE_FIELD_NAME_NOT_VALID=Field Name is not valid. {0}
 
+SCOPE_SHOULD_BE_SET_IN_ARCHIVE_WITH_DISCOVERY_MODE_ANNOTATED=Bean scope should be set in archives with bean discovery mode 'annotated'.
+
 MESSAGE_INTERCEPTOR_BINDINGS_EMPTY=Interceptor Bindings list is empty
 
 MESSAGE_STEREOTYPE_CANNOT_BE_APPLIED_TO_TYPE={0} cannot be applied to a type.

--- a/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/testmodel/CDIProject.java
+++ b/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/testmodel/CDIProject.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.jboss.tools.cdi.core.CDIConstants;
 import org.jboss.tools.cdi.core.CDICoreNature;
+import org.jboss.tools.cdi.core.CDIVersion;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IBeanMethod;
 import org.jboss.tools.cdi.core.ICDIProject;
@@ -52,7 +53,7 @@ public class CDIProject implements ICDIProject{
 	
 	private ArrayList<IQualifier> qualifiers = new ArrayList<IQualifier>();
 
-	private int version = CDIConstants.CDI_VERSION_1_0;
+	private CDIVersion version = CDIVersion.CDI_1_0;
 	
 	public CDIProject(){
 		defaultQualifier = new CDIQualifier(this, CDIConstants.DEFAULT_QUALIFIER_TYPE_NAME);
@@ -72,11 +73,11 @@ public class CDIProject implements ICDIProject{
 		qualifiers.add(new CDIQualifier(this, COMPLICATED_QUALIFIER2));
 	}
 
-	public int getVersion() {
+	public CDIVersion getVersion() {
 		return version;
 	}
 
-	public void setVersion(int version) {
+	public void setVersion(CDIVersion version) {
 		this.version = version;
 	}
 

--- a/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/NewCDIWizardTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/NewCDIWizardTest.java
@@ -40,6 +40,7 @@ import org.jboss.tools.cdi.core.ICDIAnnotation;
 import org.jboss.tools.cdi.core.ICDIProject;
 import org.jboss.tools.cdi.core.IInterceptorBinding;
 import org.jboss.tools.cdi.core.IStereotype;
+import org.jboss.tools.cdi.internal.core.scanner.lib.BeanArchiveDetector;
 import org.jboss.tools.cdi.ui.CDIUIMessages;
 import org.jboss.tools.cdi.ui.CDIUIPlugin;
 import org.jboss.tools.cdi.ui.wizard.NewAnnotationLiteralCreationWizard;
@@ -448,14 +449,28 @@ public class NewCDIWizardTest extends TestCase {
 			
 			page.setBeanName("myNewBean");
 
+			assertEquals(IMessageProvider.NONE, page.getMessageType());			
+
 			page.setScope(CDIConstants.SESSION_SCOPED_ANNOTATION_TYPE_NAME);
+
 			String message = page.getMessage();
 			assertEquals(CDIUIMessages.MESSAGE_BEAN_SHOULD_BE_SERIALIZABLE, message);
 			assertEquals(IMessageProvider.WARNING, page.getMessageType());
 
 			page.setScope(CDIConstants.APPLICATION_SCOPED_ANNOTATION_TYPE_NAME);
 			assertEquals(IMessageProvider.NONE, page.getMessageType());			
-			
+
+			cdi.getNature().setBeanDiscoveryMode(BeanArchiveDetector.ANNOTATED);
+			page.setScope("");
+			message = page.getErrorMessage();
+			assertEquals(CDIUIMessages.SCOPE_SHOULD_BE_SET_IN_ARCHIVE_WITH_DISCOVERY_MODE_ANNOTATED, message);
+
+			page.setScope(CDIConstants.APPLICATION_SCOPED_ANNOTATION_TYPE_NAME);
+			assertEquals(IMessageProvider.NONE, page.getMessageType());
+			cdi.getNature().setBeanDiscoveryMode(BeanArchiveDetector.ALL);
+			page.setScope("");
+			assertEquals(IMessageProvider.NONE, page.getMessageType());
+
 			context.wizard.performFinish();
 			
 			String text = context.getNewTypeContent();

--- a/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/OpenCDINamedBeanDialogTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.ui.test/src/org/jboss/tools/cdi/ui/test/wizard/OpenCDINamedBeanDialogTest.java
@@ -30,7 +30,7 @@ public class OpenCDINamedBeanDialogTest extends TCKTest {
 	public void testCDINamedBeanDialogSearch() throws CoreException {
 		find("spi", "SpiderSize", "OtherSpiderProducer.java", true);
 		find("bla", "blackWidow", "BlackWidowProducer.java", false);
-		find("lady", "ladybirdSpider", "SpiderProducer.java", false);
+		find("lady", "ladybirdSpider", "SpiderProducer.java", true);
 	}
 	
 	public void testCDINamedBeanDialogSearchShortHand() throws CoreException {


### PR DESCRIPTION
Added validation of scope to New CDI Bean wizard.
When project is in annotated bean discavery mode, 
empty scope input results in error message.
Test of New CDI Bean wizard is modified.
