### PR TITLE
JBIDE-15603 CDI 1.1 injecting to a point with primitive type

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
@@ -62,6 +62,7 @@ import org.jboss.tools.cdi.core.CDICoreBuilder;
 import org.jboss.tools.cdi.core.CDICoreNature;
 import org.jboss.tools.cdi.core.CDICorePlugin;
 import org.jboss.tools.cdi.core.CDIUtil;
+import org.jboss.tools.cdi.core.CDIVersion;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IBeanMethod;
 import org.jboss.tools.cdi.core.ICDIAnnotation;
@@ -1844,12 +1845,15 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 					addProblem(CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS, CDIPreferences.UNSATISFIED_OR_AMBIGUOUS_INJECTION_POINTS, reference, injection.getResource(), AMBIGUOUS_INJECTION_POINTS_ID);
 				} else if(beans.size()==1) {
 					IBean bean = beans.iterator().next();
+					if(cdiProject.getVersion() == CDIVersion.CDI_1_0) {
 					/*
+					 * CDI 1.0 specification, it is omitted since CDI 1.1:
 					 * 5.2.4. Primitive types and null values
 					 *  - injection point of primitive type resolves to a bean that may have null values, such as a producer method with a non-primitive return type or a producer field with a non-primitive type
 					 */
-					if(bean.isNullable() && injection.getType()!=null && injection.getType().isPrimitive()) {
-						addProblem(CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, CDIPreferences.INJECT_RESOLVES_TO_NULLABLE_BEAN, reference, injection.getResource());
+						if(bean.isNullable() && injection.getType()!=null && injection.getType().isPrimitive()) {
+							addProblem(CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, CDIPreferences.INJECT_RESOLVES_TO_NULLABLE_BEAN, reference, injection.getResource());
+						}
 					}
 					/*
 					 * 5.1.4. Inter-module injection

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/GameBroken.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/GameBroken.java
@@ -4,7 +4,7 @@ import javax.inject.Inject;
 
 @SuppressWarnings("unused")
 class GameBroken {
-   @Inject @PrimitiveTestQualifer private int numberBroken;
+   @Inject @PrimitiveTestQualifer private int numberBroken; //It is not broken since 1.1
 
    @Inject @PrimitiveTestQualifer private Integer number2;
    @Inject @TestQualifer private int number3;
@@ -16,7 +16,7 @@ class GameBroken {
    }
 
    @Inject
-   public void setNumber2(@PrimitiveTestQualifer int numberBroken,
+   public void setNumber2(@PrimitiveTestQualifer int numberBroken, //It is not broken since 1.1
 		   @PrimitiveTestQualifer Integer number2,
 		   @TestQualifer int number3,
 		   @TestQualifer Integer number4) {

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/validation/AYTDeploymentProblemsValidationCDI11Tests.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/validation/AYTDeploymentProblemsValidationCDI11Tests.java
@@ -10,9 +10,11 @@
  ******************************************************************************/
 package org.jboss.tools.cdi.core.test.tck11.validation;
 
+import org.eclipse.core.resources.IFile;
 import org.jboss.tools.cdi.core.test.tck.ITCKProjectNameProvider;
 import org.jboss.tools.cdi.core.test.tck.validation.AYTDeploymentProblemsValidationTests;
 import org.jboss.tools.cdi.core.test.tck11.TCK11ProjectNameProvider;
+import org.jboss.tools.cdi.internal.core.validation.CDIValidationMessages;
 
 /**
  * @author Alexey Kazakov
@@ -23,4 +25,27 @@ public class AYTDeploymentProblemsValidationCDI11Tests extends AYTDeploymentProb
 	public ITCKProjectNameProvider getProjectNameProvider() {
 		return new TCK11ProjectNameProvider();
 	}
+
+	/**
+	 * The defined in CDI 1.0 '5.2.4. Primitive types and null values' 
+	 * prohibition for an injection point of primitive type to be resolved to 
+	 * a bean that may have null values is removed from CDI 1.1 (container lets 
+	 * an injection point to have default value when resolved bean returns null 
+	 * value).
+	 * 
+	 * removed from CDI 1.1.
+	 */
+	@Override
+	public void testPrimitiveInjectionPointResolvedToNonPrimitiveProducerMethod() throws Exception {
+		IFile file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/GameBroken.java");
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 7);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 19);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 9);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 10);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 11);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 20);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 21);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 22);
+	}
+
 }

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/validation/DeploymentProblemsValidationCDI11Tests.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck11/validation/DeploymentProblemsValidationCDI11Tests.java
@@ -11,9 +11,11 @@
 
 package org.jboss.tools.cdi.core.test.tck11.validation;
 
+import org.eclipse.core.resources.IFile;
 import org.jboss.tools.cdi.core.test.tck.ITCKProjectNameProvider;
 import org.jboss.tools.cdi.core.test.tck.validation.DeploymentProblemsValidationTests;
 import org.jboss.tools.cdi.core.test.tck11.TCK11ProjectNameProvider;
+import org.jboss.tools.cdi.internal.core.validation.CDIValidationMessages;
 
 /**
  * @author Alexey Kazakov
@@ -24,4 +26,27 @@ public class DeploymentProblemsValidationCDI11Tests extends DeploymentProblemsVa
 	public ITCKProjectNameProvider getProjectNameProvider() {
 		return new TCK11ProjectNameProvider();
 	}
+
+	/**
+	 * The defined in CDI 1.0 '5.2.4. Primitive types and null values' 
+	 * prohibition for an injection point of primitive type to be resolved to 
+	 * a bean that may have null values is removed from CDI 1.1 (container lets 
+	 * an injection point to have default value when resolved bean returns null 
+	 * value).
+	 * 
+	 * removed from CDI 1.1.
+	 */
+	@Override
+	public void testPrimitiveInjectionPointResolvedToNonPrimitiveProducerMethod() throws Exception {
+		IFile file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/GameBroken.java");
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 7);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 19);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 9);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 10);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 11);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 20);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 21);
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.INJECT_RESOLVES_TO_NULLABLE_BEAN, 22);
+	}
+
 }


### PR DESCRIPTION
Validation is modified to permit in a CDI 1.1 project injecting
a bean that may have null values to a point with primitive type.
TCK1.1 test is modified respectively.
