### PR TITLE
JBIDE-16027 Build Error when using DS security module

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.deltaspike.core/src/org/jboss/tools/cdi/deltaspike/core/DeltaspikeSecurityExtension.java
+++ b/cdi/plugins/org.jboss.tools.cdi.deltaspike.core/src/org/jboss/tools/cdi/deltaspike/core/DeltaspikeSecurityExtension.java
@@ -157,6 +157,9 @@ public class DeltaspikeSecurityExtension implements ICDIExtension, IBuildPartici
 				if(t != null) {
 					List<IAnnotationDeclaration> ds1 = findSecurityBindingAnnotations(t, null, context);
 					if(ds1 != null) {
+						if(result == null) {
+							result = new ArrayList<SecurityBindingDeclaration>();
+						}
 						for (IAnnotationDeclaration d1: ds1) {
 							result.add(new SecurityBindingDeclaration(d, d1));
 						}

--- a/cdi/tests/org.jboss.tools.cdi.deltaspike.core.test/projects/DeltaspikeCoreTest/src/deltaspike/security/SecuredBean1.java
+++ b/cdi/tests/org.jboss.tools.cdi.deltaspike.core.test/projects/DeltaspikeCoreTest/src/deltaspike/security/SecuredBean1.java
@@ -34,6 +34,11 @@ public class SecuredBean1 {
 	@Secured(A.class)
     public void a() {    	
     }
+
+    @Admin
+    public void x() {
+    }
+
 }
 
 class A implements AccessDecisionVoter {


### PR DESCRIPTION
Fixed method DeltaspikeSecurityExtension.findSecurityBindingAnnotations()
Added to test bean class a method having only security stereotype
annotation. In this case the erroneous fork in method
findSecurityBindingAnnotations() is reached.
