### PR TITLE
JBIDE-16135 EL Content Assist in Java Editor: Make Content Assistant Add...

### DIFF
--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAForELJavaAndJSTCompareTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAForELJavaAndJSTCompareTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2012 Red Hat, Inc.
+ * Copyright (c) 2011-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -34,8 +34,8 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.jboss.tools.common.base.test.contentassist.CATestUtil;
 import org.jboss.tools.common.el.ui.ca.ELProposalProcessor;
 import org.jboss.tools.common.model.util.EclipseResourceUtil;
-import org.jboss.tools.jst.web.ui.internal.editor.contentassist.AutoELContentAssistantProposal;
 import org.jboss.tools.jst.jsp.test.ca.ContentAssistantTestCase;
+import org.jboss.tools.jst.web.ui.internal.editor.contentassist.AutoELContentAssistantProposal;
 import org.jboss.tools.test.util.JobUtils;
 import org.jboss.tools.test.util.ProjectImportTestSetup;
 

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAJsfAddInfoInELMessagesTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/CAJsfAddInfoInELMessagesTest.java
@@ -69,14 +69,26 @@ public class CAJsfAddInfoInELMessagesTest extends ContentAssistantTestCase {
 		int state = 0;
 		
 		// 
-		// JBIDE-16120: CSS part contains the fontnames that are OS and setup dependent,
+		// JBIDE-16135: CSS part contains the fontnames that are OS and setup dependent,
 		// So we should exclude it from compare
 		// 
 		int styleStart = html.toLowerCase().indexOf("<style");
 		int styleEnd = html.toLowerCase().indexOf("/style>");
-		if (styleStart != -1 && styleEnd > styleStart) {
+		
+		while (styleStart != -1 && styleEnd > styleStart) {
 			html = html.substring(0, styleStart) + html.substring(styleEnd + "/style>".length());
+			styleStart = html.toLowerCase().indexOf("<style");
+			styleEnd = html.toLowerCase().indexOf("/style>");
 		}
+		// JBIDE-16135: pragmas and comments should be remived also
+		int commentStart = html.indexOf("<!--");
+		int commentEnd = html.indexOf("-->");
+		while (commentStart != -1 && commentEnd > commentStart) {
+			html = html.substring(0, commentStart) + html.substring(commentEnd + "-->".length());
+			commentStart = html.indexOf("<!--");
+			commentEnd = html.indexOf("-->");
+		}
+		html = html.trim();
 		
 		for (char ch : html.toCharArray()) {
 			switch (state) {
@@ -95,7 +107,7 @@ public class CAJsfAddInfoInELMessagesTest extends ContentAssistantTestCase {
 				break;
 			}
 		}
-		return sb.toString();
+		return sb.toString().trim();
 	}
 
 	AutoELContentAssistantProposal[] getJSTProposals(String prefix) {

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/hover/ELTooltipTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/hover/ELTooltipTest.java
@@ -40,15 +40,11 @@ public class ELTooltipTest extends ContentAssistantTestCase {
 			};
 	private static final String EL_VALUE[] = {"user", "name", "sayHello", "msgs", "prompt"};
 	private static final String EL_TOOLTIP_TEXT[] = {
-		"<html><body text=\"#000000\" bgcolor=\"#ffffe1\"><h5><img style='position: relative; width: 16px; height: 16px; top: 2px; left: 2px; ' src='file:/home/jeremy/projects/junit-workspace/.metadata/.plugins/org.eclipse.jdt.ui/jdt-images/0.png'>\n" + 
-				"<span style='word-wrap:break-word;margin-left: 2px; margin-top: 2px; '>demo.User</span></span></h5><p>Created by JBoss Tools</body></html>",
-		"<html><body text=\"#000000\" bgcolor=\"#ffffe1\">- <span style='word-wrap:break-word;'><a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User~getName%E2%98%82String'>String</a> demo.<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User'>User</a>.getName()</span><br/>- <span style='word-wrap:break-word;'>void demo.<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User'>User</a>.setName(<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User~setName~QString;%E2%98%82String'>String</a> name)</span><br/><br/><h5><img style='position: relative; width: 16px; height: 16px; top: 2px; left: 2px; ' src='file:/home/jeremy/projects/junit-workspace/.metadata/.plugins/org.eclipse.jdt.ui/jdt-images/1.png'>\n" +
-				"<span style='word-wrap:break-word;margin-left: 2px; margin-top: 2px; '><a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User~getName%E2%98%82String'>String</a> demo.<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User'>User</a>.getName()</span></span></h5><br/>\n" +
-				"<span style='word-wrap:break-word;margin-left: 2px; margin-top: 2px; '>void demo.<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User'>User</a>.setName(<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User~setName~QString;%E2%98%82String'>String</a> name)</span></span></h5><h5><img style='position: relative; width: 16px; height: 16px; top: 2px; left: 2px; ' src='file:/home/jeremy/projects/junit-workspace/.metadata/.plugins/org.eclipse.jdt.ui/jdt-images/1.png'></body></html>",
-		"<html><body text=\"#000000\" bgcolor=\"#ffffe1\"><h5><img style='position: relative; width: 16px; height: 16px; top: 2px; left: 2px; ' src='file:/home/jeremy/projects/junit-workspace/.metadata/.plugins/org.eclipse.jdt.ui/jdt-images/1.png'>\n" +
-				"<span style='word-wrap:break-word;margin-left: 2px; margin-top: 2px; '><a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User~sayHello%E2%98%82String'>String</a> demo.<a class='header' href='eclipse-javadoc:%E2%98%82=JSF2KickStartWithoutLibs/JavaSource%3Cdemo%7BUser.java%E2%98%83User'>User</a>.sayHello()</span></span></h5></body></html>",
-		"Base Name: resources<br><br>Resource Bundle: /JSF2KickStartWithoutLibs/JavaSource/resources.properties<br>",
-		"Property: prompt<br>Base Name: resources<br><br>Resource Bundle: /JSF2KickStartWithoutLibs/JavaSource/resources.properties<br>Value: Your Name:<br><br>"
+		"demo.UserCreated by JBoss Tools",
+		"String demo.User.getName()No Javadoc could be found     void demo.User.setName(String name)No Javadoc could be found",
+		"String demo.User.sayHello()No Javadoc could be found",
+		"Base Name: resourcesResource Bundle: /JSF2KickStartWithoutLibs/JavaSource/resources.properties",
+		"Property: promptBase Name: resourcesResource Bundle: /JSF2KickStartWithoutLibs/JavaSource/resources.propertiesValue: Your Name:"
 				
 	};
 	
@@ -86,6 +82,29 @@ public class ELTooltipTest extends ContentAssistantTestCase {
 	String html2Text(String html) {
 		StringBuilder sb = new StringBuilder();
 		int state = 0;
+		
+		// 
+		// JBIDE-16135: CSS part contains the fontnames that are OS and setup dependent,
+		// So we should exclude it from compare
+		// 
+		int styleStart = html.toLowerCase().indexOf("<style");
+		int styleEnd = html.toLowerCase().indexOf("/style>");
+		
+		while (styleStart != -1 && styleEnd > styleStart) {
+			html = html.substring(0, styleStart) + html.substring(styleEnd + "/style>".length());
+			styleStart = html.toLowerCase().indexOf("<style");
+			styleEnd = html.toLowerCase().indexOf("/style>");
+		}
+		// JBIDE-16135: pragmas and comments should be remived also
+		int commentStart = html.indexOf("<!--");
+		int commentEnd = html.indexOf("-->");
+		while (commentStart != -1 && commentEnd > commentStart) {
+			html = html.substring(0, commentStart) + html.substring(commentEnd + "-->".length());
+			commentStart = html.indexOf("<!--");
+			commentEnd = html.indexOf("-->");
+		}
+		html = html.trim();
+		
 		for (char ch : html.toCharArray()) {
 			switch (state) {
 			case (int)'<':
@@ -103,8 +122,9 @@ public class ELTooltipTest extends ContentAssistantTestCase {
 				break;
 			}
 		}
-		return sb.toString();
+		return sb.toString().trim();
 	}
+
 	
 	public ITextHover getTextHover(ITextViewer viewer, int offset) {
 		try {

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/JsfUiAllTests.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/ui/test/JsfUiAllTests.java
@@ -149,8 +149,7 @@ public class JsfUiAllTests {
 		suite.addTest(new ProjectImportTestSetup(new TestSuite(
 				CAJsfMessagesProposalsFilteringTest.class,
 				ELTooltipTest.class,
-//	TODO: The following test should be fixed and uncommented after the issue JBIDE-16135 is fixed: 		
-//				CAForELJavaAndJSTCompareTest.class,
+				CAForELJavaAndJSTCompareTest.class,
 				CAELApplyMethodProposalTest.class,
 				CAJsfAddInfoInELMessagesTest.class,
 				CAJsfResourceBundlePropertyApplyTest.class,


### PR DESCRIPTION
...itional Info window to support URLs.

JUnit tests were fixed after changing the Content Assist Additional Info's and Tooltip's (Hover's) content.

Signed-off-by: vrubezhny vrubezhny@exadel.com
