### PR TITLE
JBIDE-16283 wizards are not visible with filter in dialog "New Project",...

### DIFF
--- a/jsf/plugins/org.jboss.tools.jsf.ui/plugin.xml
+++ b/jsf/plugins/org.jboss.tools.jsf.ui/plugin.xml
@@ -111,7 +111,7 @@
             parentCategory="org.jboss.tools.jst.web">
       </category>
       <wizard
-            category="org.jboss.tools.jst.web/org.jboss.tools.jsf"
+            category="org.jboss.tools.jsf"
             class="org.jboss.tools.jsf.ui.wizard.newfile.NewFacesConfigFileWizard"
             finalPerspective="org.jboss.tools.jst.web.ui.WebDevelopmentPerspective"
             icon="$nl$/images/xstudio/wizards/jsf-config.gif"
@@ -125,7 +125,7 @@
          </selection>
       </wizard>
       <wizard
-            category="org.jboss.tools.jst.web/org.jboss.tools.jsf"
+            category="org.jboss.tools.jsf"
             class="org.jboss.tools.jsf.ui.wizard.project.NewProjectWizard"
             finalPerspective="org.jboss.tools.jst.web.ui.WebDevelopmentPerspective"
             icon="$nl$/images/xstudio/wizards/new_jsf_project.gif"


### PR DESCRIPTION
... and "other"

Update attribute category for wizards in newWizards extension
