### PR TITLE
JBIDE-15373 Check all code run by builders for thread safety

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/CDICoreNature.java
@@ -299,7 +299,11 @@ public class CDICoreNature implements IProjectNature {
 
 	private void getAllDependentProjects(Map<CDICoreNature, Integer> result, int level) {
 		if(level > 10) return;
-		for (CDICoreNature n:usedBy) {
+		CDICoreNature[] array = null;
+		synchronized(this) {
+			array = usedBy.toArray(new CDICoreNature[0]);
+		}
+		for (CDICoreNature n: usedBy) {
 			if(!result.containsKey(n) || result.get(n).intValue() < level) {
 				result.put(n, level);
 				n.getAllDependentProjects(result, level + 1);


### PR DESCRIPTION
Fixed code that failed with a big probability at adding/removing
CDI nature to projects in wildfly.
