### PR TITLE
JBIDE-16415 Shortcut for Redo action is missing

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
+++ b/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
@@ -620,14 +620,6 @@
    <extension
          point="org.eclipse.ui.bindings">
       <key
-            commandId="org.jboss.tools.seam.ui.open.component"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+M2+Z">
-      </key>
-      <!--             
-      contextId="org.jboss.tools.vpe.editorContext"
-      -->
-      <key
             commandId="org.jboss.tools.seam.ui.find.declarations"
 		      contextId="org.eclipse.wst.sse.ui.structuredTextEditorScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
@@ -706,7 +698,6 @@
 		<menuContribution locationURI="menu:navigate?after=open.ext2">
 			<command commandId="org.jboss.tools.seam.ui.open.component"
             	id="org.jboss.tools.seam.ui.openComponent"
-              	mnemonic="Z"
      			icon="$nl$/icons/open_seam_component.gif"
               	label="%NavigateMenu_OpenSeamComponents"
               	tooltip="%NavigateMenu_OpenSeamComponents" >
@@ -717,7 +708,6 @@
         	<toolbar id="org.eclipse.search.searchActionSet">
             	<command commandId="org.jboss.tools.seam.ui.open.component"
                 	id="org.jboss.tools.seam.ui.openComponent"
-                  	mnemonic="Z"
       				icon="$nl$/icons/open_seam_component.gif"
                   	label="%NavigateMenu_OpenSeamComponents"
                   	tooltip="%NavigateMenu_OpenSeamComponents" >


### PR DESCRIPTION
The shortcut for "Open Seam Component" action is changed to be Ctrl-Y, because of overlapping
with the shortcut reserved for Redo action in Windows (was Ctrl-Shift-Z).

Signed-off-by: vrubezhny vrubezhny@exadel.com
