### PR TITLE
JBIDE-16416 Shortcut for Redo action is missing

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
+++ b/seam/plugins/org.jboss.tools.seam.ui/plugin.xml
@@ -609,14 +609,6 @@
    <extension
          point="org.eclipse.ui.bindings">
       <key
-            commandId="org.jboss.tools.seam.ui.open.component"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+M2+Z">
-      </key>
-      <!--             
-      contextId="org.jboss.tools.vpe.editorContext"
-      -->
-      <key
             commandId="org.jboss.tools.seam.ui.find.declarations"
 		      contextId="org.eclipse.wst.sse.ui.structuredTextEditorScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"


### PR DESCRIPTION
The shortcut for "Open Seam Component" action is removed as not too often used and because of overlapping
with the shortcut reserved for Redo action in Windows (was Ctrl-Shift-Z).

Signed-off-by: vrubezhny vrubezhny@exadel.com
