### PR TITLE
JBIDE-16986 HTML Editor: 'Open a Tag Library' appears in wrong place

### DIFF
--- a/jsf/plugins/org.jboss.tools.jsf.text.ext/src/org/jboss/tools/jsf/text/ext/hyperlink/JsfJSPTagNameHyperlinkDetector.java
+++ b/jsf/plugins/org.jboss.tools.jsf.text.ext/src/org/jboss/tools/jsf/text/ext/hyperlink/JsfJSPTagNameHyperlinkDetector.java
@@ -64,6 +64,7 @@ public class JsfJSPTagNameHyperlinkDetector extends AbstractHyperlinkDetector {
 			Node n = Utils.findNodeForOffset(xmlDocument, region.getOffset());
 			
 			IRegion reg = getRegion(n, region.getOffset());
+			boolean prefixExist = false;
 			
 			if(reg != null && n instanceof IDOMElement) {
 				String tagName = n.getNodeName();
@@ -71,8 +72,12 @@ public class JsfJSPTagNameHyperlinkDetector extends AbstractHyperlinkDetector {
 				KbQuery query = new KbQuery();
 				query.setType(KbQuery.Type.TAG_NAME);
 				
-				if(i > 0) query.setPrefix(tagName.substring(0, i));
-				else query.setPrefix("");
+				if(i > 0){
+					query.setPrefix(tagName.substring(0, i));
+					prefixExist = true;
+				}else{
+					query.setPrefix("");
+				}
 				
 				query.setOffset(reg.getOffset());
 				query.setValue(tagName);
@@ -101,8 +106,12 @@ public class JsfJSPTagNameHyperlinkDetector extends AbstractHyperlinkDetector {
 				KbQuery query = new KbQuery();
 				query.setType(KbQuery.Type.ATTRIBUTE_NAME);
 				
-				if(i > 0) query.setPrefix(tagName.substring(0, i));
-				else query.setPrefix("");
+				if(i > 0){
+					query.setPrefix(tagName.substring(0, i));
+					prefixExist = true;
+				}else{
+					query.setPrefix("");
+				}
 				
 				query.setUri(getURI(region, textViewer.getDocument()));
 				query.setParentTags(new String[]{tagName});
@@ -128,8 +137,10 @@ public class JsfJSPTagNameHyperlinkDetector extends AbstractHyperlinkDetector {
 						return (IHyperlink[]) hyperlinks.toArray(new IHyperlink[hyperlinks.size()]);
 				}
 			}
-			
-			return parse(textViewer.getDocument(), xmlDocument, region);
+			if(prefixExist){
+				return parse(textViewer.getDocument(), xmlDocument, region);
+			}
+			return null;
 		} finally {
 			smw.dispose();
 		}


### PR DESCRIPTION
Updated hyperlink detector in order not to show hyperlink 'Open a Tag Library' in case there is no tag prefix
