### PR TITLE
JBIDE-16947 Beans are not automatically validated when beans.xml is changed

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/IExcluded.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/core/IExcluded.java
@@ -10,7 +10,7 @@
  ******************************************************************************/ 
 package org.jboss.tools.cdi.core;
 
-import org.eclipse.jdt.core.IType;
+import org.eclipse.core.runtime.IPath;
 
 /**
  * 
@@ -18,6 +18,8 @@ import org.eclipse.jdt.core.IType;
  *
  */
 public interface IExcluded {
+
+	public IPath getSource();
 
 	/**
 	 * 

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
@@ -1285,8 +1285,15 @@ public class CDIProject extends CDIElement implements ICDIProject, Cloneable {
 			newDefinitionToClassbeans.put(typeDefinition, bean);
 
 			String typeName = typeDefinition.getType().getFullyQualifiedName();
-			if(!typeDefinition.isVetoed() 
-					&& !isExcluded(typeName, excluded)
+			boolean vetoed = typeDefinition.isVetoed();
+			IPath isexcludedBy = null;
+			if(!vetoed) {
+				isexcludedBy = isExcludedBy(typeName, excluded);
+				if(isexcludedBy != null) {
+					getNature().getDefinitions().addDependency(isexcludedBy, typeDefinition.getType().getPath());
+				}
+			}
+			if(!vetoed && isexcludedBy == null
 					    //Type is defined in another project and modified/replaced in config in this (dependent) project
 					    //We should reject type definition based on type, but we have to accept 
 					&& !(vetoedTypes.contains(typeName) && getNature().getDefinitions().getTypeDefinition(typeName) == null && typeDefinition.getOriginalDefinition() == null)) {
@@ -1343,13 +1350,13 @@ public class CDIProject extends CDIElement implements ICDIProject, Cloneable {
 	
 	}
 
-	private boolean isExcluded(String typeName, Collection<IExcluded> excluded) {
+	private IPath isExcludedBy(String typeName, Collection<IExcluded> excluded) {
 		for (IExcluded e: excluded) {
 			if(e.isExcluded(typeName)) {
-				return true;
+				return e.getSource();
 			}
 		}
-		return false;
+		return null;
 	}
 	
 	/**

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/Excluded.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/Excluded.java
@@ -13,6 +13,7 @@ package org.jboss.tools.cdi.internal.core.impl;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IType;
 import org.jboss.tools.cdi.core.ICDIProject;
 import org.jboss.tools.cdi.core.IExcluded;
@@ -29,7 +30,16 @@ public class Excluded implements IExcluded {
 	private List<String> typesAvailable = EMPTY;
 	private List<String> typesNotAvailable = EMPTY;
 
-	public Excluded() {}
+	private IPath source = null;
+
+	public Excluded(IPath source) {
+		this.source = source;
+	}
+
+	@Override
+	public IPath getSource() {
+		return source;
+	}
 
 	@Override
 	public boolean isExcluded(String typeName) {

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/definition/BeansXMLDefinition.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/definition/BeansXMLDefinition.java
@@ -86,7 +86,7 @@ public class BeansXMLDefinition implements CDIBeansConstants {
 			if("exclude".equals(c.getAttributeValue(XModelObjectConstants.ATTR_ELEMENT_TYPE))) {
 				String name = c.getAttributeValue(XModelObjectConstants.ATTR_NAME);
 				if(name == null || name.startsWith("!")) continue; //not supported
-				Excluded excluded = new Excluded();
+				Excluded excluded = new Excluded(path);
 				excluded.setFilter(name);
 				XModelObject[] cs2 = c.getChildren();
 				for (XModelObject c2: cs2) {

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/weld1.1/src/META-INF/beans.modified
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/weld1.1/src/META-INF/beans.modified
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:s="urn:java:ee"
+ xmlns:tb="urn:java:com.exadel.tiggzi.bootstrap"
+ xmlns:weld="http://jboss.org/schema/weld/beans"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/schema/cdi/beans_1_0.xsd http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+
+ <weld:scan>
+  <weld:exclude name="exclude.p2.*"/>
+  <weld:exclude name="exclude.p4.**">
+  	<weld:if-class-available name="exclude.p4.Bean5"/>
+  	<weld:if-class-available name="!exclude.p6.DoesNotExist"/>
+  </weld:exclude>
+  <weld:exclude name="exclude.p6.**">
+  	<weld:if-class-available name="exclude.p6.DoesNotExist"/>
+  </weld:exclude>
+ </weld:scan>
+ 
+ </beans>

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/weld1.1/src/META-INF/beans.original
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/weld1.1/src/META-INF/beans.original
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:s="urn:java:ee"
+ xmlns:tb="urn:java:com.exadel.tiggzi.bootstrap"
+ xmlns:weld="http://jboss.org/schema/weld/beans"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/schema/cdi/beans_1_0.xsd http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+
+ <weld:scan>
+  <weld:exclude name="exclude.p1.Bean1"/>
+  <weld:exclude name="exclude.p2.*"/>
+  <weld:exclude name="exclude.p4.**">
+  	<weld:if-class-available name="exclude.p4.Bean5"/>
+  	<weld:if-class-available name="!exclude.p6.DoesNotExist"/>
+  </weld:exclude>
+  <weld:exclude name="exclude.p6.**">
+  	<weld:if-class-available name="exclude.p6.DoesNotExist"/>
+  </weld:exclude>
+ </weld:scan>
+ 
+ </beans>

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDICoreAllTests.java
@@ -79,6 +79,7 @@ import org.jboss.tools.cdi.core.test.tck.validation.ELValidationTest;
 import org.jboss.tools.cdi.core.test.tck.validation.IncrementalValidationTest;
 import org.jboss.tools.cdi.core.test.tck.validation.MissingBeansXmlValidationTest;
 import org.jboss.tools.cdi.core.test.tck.validation.SuppressWarningsTests;
+import org.jboss.tools.cdi.core.test.tck.validation.WeldExcludeIncrementalValidationTest;
 import org.jboss.tools.cdi.core.test.tck.validation.WeldValidationTest;
 import org.jboss.tools.cdi.core.test.tck11.AssignabilityOfRawAndParameterizedTypesCDI11Test;
 import org.jboss.tools.cdi.core.test.tck11.BeanDefinitionCDI11Test;
@@ -241,6 +242,7 @@ public class CDICoreAllTests {
 		TestSuite weldSuite = new TestSuite("Weld Tests");
 		weldSuite.addTestSuite(BuiltInContextBeanInjectionWeldTest.class);
 		weldSuite.addTestSuite(WeldExcludeTest.class);
+		weldSuite.addTestSuite(WeldExcludeIncrementalValidationTest.class);
 		ProjectImportTestSetup weldTestSetup = new ProjectImportTestSetup(weldSuite,
 				"org.jboss.tools.cdi.core.test",
 				new String[]{"projects/weld1.1"},

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/WeldExcludeIncrementalValidationTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/WeldExcludeIncrementalValidationTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.cdi.core.test.tck.validation;
+
+import java.util.Collection;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.jboss.tools.cdi.core.CDICorePlugin;
+import org.jboss.tools.cdi.core.IBean;
+import org.jboss.tools.cdi.core.ICDIProject;
+import org.jboss.tools.cdi.core.IInjectionPointField;
+import org.jboss.tools.cdi.core.test.DependentProjectTest;
+import org.jboss.tools.cdi.internal.core.validation.CDIValidationMessages;
+import org.jboss.tools.common.base.test.validation.TestUtil;
+import org.jboss.tools.tests.AbstractResourceMarkerTest;
+
+import junit.framework.TestCase;
+
+public class WeldExcludeIncrementalValidationTest extends TestCase {
+	protected static String PLUGIN_ID = "org.jboss.tools.cdi.core.test";
+	IProject project = null;
+	ICDIProject cdi;
+	String fileName = "src/test/TestExcluded.java";
+
+	public WeldExcludeIncrementalValidationTest() {}
+
+	public void setUp() throws Exception {
+		project = ResourcesPlugin.getWorkspace().getRoot().getProject("weld1.1");
+//		project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
+		cdi = CDICorePlugin.getCDIProject(project, true);
+	}
+
+	//<weld:exclude name="exclude.p1.Bean1"/>
+	public void testExactMatch() throws Exception {
+		IFile bean_xml = project.getFile("src/META-INF/beans.xml");
+		//Bean exclude.p1.Bean1 is excluded
+		IInjectionPointField bean1 = getInjectionPointField(cdi, fileName, "bean1");
+		TestUtil.validate(bean_xml);
+		AbstractResourceMarkerTest.assertMarkerIsCreated(bean1.getResource(), CDIValidationMessages.UNSATISFIED_INJECTION_POINTS, 14, 16, 18, 19);
+
+		IFile beans_modified = project.getFile("src/META-INF/beans.modified");
+		bean_xml.setContents(beans_modified.getContents(), IFile.FORCE, new NullProgressMonitor());
+		TestUtil.validate(bean_xml);
+		AbstractResourceMarkerTest.assertMarkerIsCreated(bean1.getResource(), CDIValidationMessages.UNSATISFIED_INJECTION_POINTS, 16, 18, 19);
+
+		IFile beans_original = project.getFile("src/META-INF/beans.original");
+		bean_xml.setContents(beans_original.getContents(), IFile.FORCE, new NullProgressMonitor());
+		TestUtil.validate(bean_xml);
+		AbstractResourceMarkerTest.assertMarkerIsCreated(bean1.getResource(), CDIValidationMessages.UNSATISFIED_INJECTION_POINTS, 14, 16, 18, 19);
+	}
+
+	protected IInjectionPointField getInjectionPointField(ICDIProject cdi, String beanClassFilePath, String fieldName) {
+		return DependentProjectTest.getInjectionPointField(cdi, beanClassFilePath, fieldName);
+	}
+}


### PR DESCRIPTION
Dependency between beans.xml and excluded resources are added to project context.
Test is added.
