### PR TITLE
JBIDE-17185 org.jboss.tools.cdi.core.test failures on Windows

### DIFF
--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/RemoveJarFromClasspathTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/RemoveJarFromClasspathTest.java
@@ -86,7 +86,7 @@ public class RemoveJarFromClasspathTest extends TestCase {
 	private boolean contains(Libs libs, String path) {
 		List<String> paths = libs.getPaths();
 		for (String p: paths) {
-			if(p.endsWith(path)) return true;
+			if(p.replace('\\',  '/').endsWith(path)) return true;
 		}
 		return false;
 	}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/BeanDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/BeanDefinitionTest.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.IBean;
@@ -33,7 +34,7 @@ public class BeanDefinitionTest extends TCKTest {
 	 *   a) A bean comprises of a (nonempty) set of bean types.
 	 * @throws JavaModelException 
 	 */
-	public void testBeanTypesNonEmpty() throws JavaModelException {
+	public void testBeanTypesNonEmpty() throws CoreException {
 		IFile file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/definition/bean/RedSnapper.java");
 		Collection<IBean> beans = cdiProject.getBeans(file.getFullPath());
 		assertEquals("There should be the only bean in org.jboss.jsr299.tck.tests.definition.bean.RedSnapper", 1, beans.size());
@@ -43,8 +44,9 @@ public class BeanDefinitionTest extends TCKTest {
 		assertTrue("No legal types were found for org.jboss.jsr299.tck.tests.definition.bean.RedSnapper bean.", bean.getLegalTypes().size() > 0);
 		Collection<ITypeDeclaration> declarations = bean.getAllTypeDeclarations();
 		assertEquals("There should be two type declarations in org.jboss.jsr299.tck.tests.definition.bean.RedSnapper bean.", declarations.size(), 2);
-		assertLocationEquals(declarations, 914, 10);
-		assertLocationEquals(declarations, 936, 6);
+		file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "lass RedSnapper implement", 5/*914*/, 10);
+		assertLocationEquals(file, declarations, "ents Animal", 5/*936*/, 6);
 	}
 
 	/**
@@ -124,7 +126,7 @@ public class BeanDefinitionTest extends TCKTest {
 	 * section 2.2 l)
 	 * section 11.1 ba)
 	 */
-	public void testBeanTypes() throws JavaModelException {
+	public void testBeanTypes() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.bean.Tarantula");
 		assertEquals("There should be the only bean with org.jboss.jsr299.tck.tests.definition.bean.Tarantula type", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -137,9 +139,11 @@ public class BeanDefinitionTest extends TCKTest {
 
 		Collection<ITypeDeclaration> declarations = bean.getAllTypeDeclarations();
 		assertEquals("There should be three type declarations in org.jboss.jsr299.tck.tests.definition.bean.Tarantula bean.", declarations.size(), 3);
-		assertLocationEquals(declarations, 841, 9);
-		assertLocationEquals(declarations, 859, 6);
-		assertLocationEquals(declarations, 877, 12);
+		//TODOs
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "lass Tarantula exte", 5/*841*/, 9);
+		assertLocationEquals(file, declarations, "ends Spider implement", 5/*859*/, 6);
+		assertLocationEquals(file, declarations, "ents DeadlySpider", 5/*877*/, 12);
 	}
 
 	/**
@@ -147,7 +151,7 @@ public class BeanDefinitionTest extends TCKTest {
 	 *
 	 * @throws JavaModelException
 	 */
-	public void testAbstractApiType() throws JavaModelException {
+	public void testAbstractApiType() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.bean.FriendlyAntelope");
 		assertEquals("There should be the only bean with org.jboss.jsr299.tck.tests.definition.bean.FriendlyAntelope type", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -158,8 +162,9 @@ public class BeanDefinitionTest extends TCKTest {
 
 		Collection<ITypeDeclaration> declarations = bean.getAllTypeDeclarations();
 		assertEquals("There should be three type declarations in org.jboss.jsr299.tck.tests.definition.bean.FriendlyAntelope bean.", declarations.size(), 2);
-		assertLocationEquals(declarations, 842, 16);
-		assertLocationEquals(declarations, 867, 16);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "lass FriendlyAntelope extends A", 5/*842*/, 16);
+		assertLocationEquals(file, declarations, "ends AbstractAntelope", 5/*867*/, 16);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/NameDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/NameDefinitionTest.java
@@ -12,6 +12,8 @@ package org.jboss.tools.cdi.core.test.tck;
 
 import java.util.Collection;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.IBean;
 
@@ -26,22 +28,24 @@ public class NameDefinitionTest extends TCKTest {
 	 *
 	 * @throws JavaModelException 
 	 */
-	public void testNonDefaultNamed() throws JavaModelException {
+	public void testNonDefaultNamed() throws CoreException {
 //		IFile file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/definition/name/Moose.java");
 //		Collection<IBean> beans = cdiProject.getBeans(file.getFullPath());
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.name.Moose");
 		assertEquals("There should be the only bean with org.jboss.jsr299.tck.tests.definition.name.Moose type.", 1, beans.size());
 		IBean bean = beans.iterator().next();
 		assertEquals("Wrong EL name of org.jboss.jsr299.tck.tests.definition.name.Moose bean.", "aMoose", bean.getName());
-		assertLocationEquals(bean.getNameLocation(true), 897, 16);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, "@Named(\"aMoose\") @Default", bean.getNameLocation(true), 0/*897*/, 16);
 	}
 
-	public void testNamedWithConstant() throws JavaModelException {
+	public void testNamedWithConstant() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.name.Bear");
 		assertEquals("There should be the only bean with org.jboss.jsr299.tck.tests.definition.name.Bear type.", 1, beans.size());
 		IBean bean = beans.iterator().next();
 		assertEquals("Wrong EL name of org.jboss.jsr299.tck.tests.definition.name.Bear bean.", "aBear", bean.getName());
-		assertLocationEquals(bean.getNameLocation(true), 897, 17);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, "@Named(Bear.NAME)", bean.getNameLocation(true), 0/*897*/, 17);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/ProducerMethodDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/ProducerMethodDefinitionTest.java
@@ -12,13 +12,16 @@ package org.jboss.tools.cdi.core.test.tck;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.StringTokenizer;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IInjectionPoint;
 import org.jboss.tools.cdi.core.IParameter;
 import org.jboss.tools.cdi.core.IProducerMethod;
+import org.jboss.tools.common.util.FileUtil;
 
 /**
  * @author Alexey Kazakov
@@ -31,14 +34,16 @@ public class ProducerMethodDefinitionTest extends TCKTest {
 	 *
 	 * @throws JavaModelException 
 	 */
-	public void testBindingTypesAppliedToProducerMethodParameters() throws JavaModelException {
+	public void testBindingTypesAppliedToProducerMethodParameters() throws CoreException {
 		Collection<IBean> beans = cdiProject.getBeans(true, "org.jboss.jsr299.tck.tests.implementation.producer.method.definition.Tarantula", "org.jboss.jsr299.tck.tests.implementation.producer.method.definition.Deadliest");
 		IBean bean = beans.iterator().next();
 		Collection<IInjectionPoint> injections = bean.getInjectionPoints();
 		assertEquals("Wrong number of injection points in the producer.", 2, injections.size());
 		// TODO use real location for injection points.
-		assertLocationEquals(injections, 1287, 29);
-		assertLocationEquals(injections, 1328, 19);
+		
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, injections, "@Tame Tarantula tameTarantula", 0/*1287*/, 29);
+		assertLocationEquals(file, injections, "Tarantula tarantula)", 0/*1328*/, 19);
 	}
 
 	// TODO continue implementing producer tests.

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/QualifierDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/QualifierDefinitionTest.java
@@ -12,6 +12,7 @@ package org.jboss.tools.cdi.core.test.tck;
 
 import java.util.Collection;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -88,15 +89,16 @@ public class QualifierDefinitionTest extends TCKTest {
 		assertEquals("Wrong number of qualifiers.", 2, qualifiers.size());
 		assertContainsQualifier(bean, synchronous);
 		Collection<IQualifierDeclaration> declarations = bean.getQualifierDeclarations();
+		IFile file = (IFile)bean.getResource();
 		assertEquals("Wrong number of qualifier declarations.", 1, declarations.size());
-		assertLocationEquals(declarations, 836, 12);
+		assertLocationEquals(file, declarations, "@Synchronous", 0/*836*/, 12);
 	}
 
 	/**
 	 * section 2.3.3 d)
 	 * @throws JavaModelException 
 	 */
-	public void testMultipleQualifiers() throws JavaModelException {
+	public void testMultipleQualifiers() throws CoreException {
 		IQualifierDeclaration chunky = getQualifierDeclarationFromClass("JavaSource/org/jboss/jsr299/tck/tests/definition/qualifier/Cod.java", "org.jboss.jsr299.tck.tests.definition.qualifier.Chunky");
 		IQualifierDeclaration whitefish = getQualifierDeclarationFromClass("JavaSource/org/jboss/jsr299/tck/tests/definition/qualifier/Cod.java", "org.jboss.jsr299.tck.tests.definition.qualifier.Whitefish");
 		IParametedType type = getType("org.jboss.jsr299.tck.tests.definition.qualifier.Cod");
@@ -107,15 +109,16 @@ public class QualifierDefinitionTest extends TCKTest {
 		assertEquals("Wrong number of qualifiers.", 4, qualifiers.size());
 		Collection<IQualifierDeclaration> declarations = bean.getQualifierDeclarations();
 		assertEquals("Wrong number of qualifier declarations.", 3, declarations.size());
-		assertLocationEquals(declarations, 862, 10);
-		assertLocationEquals(declarations, 873, 24);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@Whitefish", 0/*862*/, 10);
+		assertLocationEquals(file, declarations, "@Chunky(realChunky=true)", 0/*873*/, 24);
 	}
 
 	/**
 	 * section 2.3.5 a)
 	 * @throws JavaModelException 
 	 */
-	public void testFieldInjectedFromProducerMethod() throws JavaModelException {
+	public void testFieldInjectedFromProducerMethod() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.qualifier.Barn");
 		assertEquals("Wrong number of beans with org.jboss.jsr299.tck.tests.definition.qualifier.Barn type.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -123,7 +126,8 @@ public class QualifierDefinitionTest extends TCKTest {
 		IInjectionPoint point = points.iterator().next();
 		Collection<IQualifierDeclaration> declarations = point.getQualifierDeclarations();
 		assertEquals("Wrong number of qualifier declarations.", 1, declarations.size());
-		assertLocationEquals(declarations, 891, 5);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "ject @Tame", 5/*891*/, 5);
 
 		Collection<IBean> injectedBeans = cdiProject.getBeans(true, point);
 		assertEquals("Wrong number of beans.", 1, injectedBeans.size());
@@ -134,7 +138,8 @@ public class QualifierDefinitionTest extends TCKTest {
 		IProducerMethod producer = (IProducerMethod)injectedBean;
 		declarations = producer.getQualifierDeclarations();
 		assertEquals("Wrong number of qualifier declarations.", 1, declarations.size());
-		assertLocationEquals(declarations, 916, 5);
+		file = (IFile)injectedBean.getResource();
+		assertLocationEquals(file, declarations, "uces @Tame publ", 5/*916*/, 5);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/ScopeDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/ScopeDefinitionTest.java
@@ -12,6 +12,8 @@ package org.jboss.tools.cdi.core.test.tck;
 
 import java.util.Collection;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IScopeDeclaration;
@@ -26,7 +28,7 @@ public class ScopeDefinitionTest extends TCKTest {
 	 * 
 	 * @throws JavaModelException
 	 */
-	public void testScopeTypesAreExtensible() throws JavaModelException {
+	public void testScopeTypesAreExtensible() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.scope.Mullet");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -36,7 +38,8 @@ public class ScopeDefinitionTest extends TCKTest {
 		Collection<IScopeDeclaration> declarations = bean.getScopeDeclarations();
 		assertEquals("Wrong number of scope declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 830, 17);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@AnotherScopeType", 0/*830*/, 17);
 	}
 
 	/**
@@ -44,7 +47,7 @@ public class ScopeDefinitionTest extends TCKTest {
 	 * 
 	 * @throws JavaModelException
 	 */
-	public void testScopeDeclaredInJava() throws JavaModelException {
+	public void testScopeDeclaredInJava() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.scope.SeaBass");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -54,7 +57,8 @@ public class ScopeDefinitionTest extends TCKTest {
 		Collection<IScopeDeclaration> declarations = bean.getScopeDeclarations();
 		assertEquals("Wrong number of scope declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 878, 14);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@RequestScoped", 0/*878*/, 14);
 	}
 
 	/**
@@ -75,7 +79,7 @@ public class ScopeDefinitionTest extends TCKTest {
 	 * 
 	 * @throws JavaModelException
 	 */
-	public void testScopeSpecifiedAndStereotyped() throws JavaModelException {
+	public void testScopeSpecifiedAndStereotyped() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.scope.Minnow");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -85,7 +89,8 @@ public class ScopeDefinitionTest extends TCKTest {
 		Collection<IScopeDeclaration> declarations = bean.getScopeDeclarations();
 		assertEquals("Wrong number of scope declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 899, 14);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@RequestScoped", 0/*899*/, 14);
 	}
 
 	/**
@@ -94,7 +99,7 @@ public class ScopeDefinitionTest extends TCKTest {
 	 * @throws JavaModelException
 	 */
 	public void testMultipleIncompatibleScopeStereotypesWithScopeSpecified()
-			throws JavaModelException {
+			throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.scope.Pollock");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -103,7 +108,8 @@ public class ScopeDefinitionTest extends TCKTest {
 		Collection<IScopeDeclaration> declarations = bean.getScopeDeclarations();
 		assertEquals("Wrong number of scope declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 908, 10);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@Dependent", 0/*908*/, 10);
 	}
 
 	/**
@@ -127,7 +133,7 @@ public class ScopeDefinitionTest extends TCKTest {
 	 * @throws JavaModelException
 	 */
 	public void testWebBeanScopeTypeOverridesStereotype()
-			throws JavaModelException {
+			throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.scope.RedSnapper");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -137,7 +143,8 @@ public class ScopeDefinitionTest extends TCKTest {
 		Collection<IScopeDeclaration> declarations = bean.getScopeDeclarations();
 		assertEquals("Wrong number of scope declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 894, 14);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@RequestScoped", 0/*894*/, 14);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/StereotypeDefinitionTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/StereotypeDefinitionTest.java
@@ -12,6 +12,8 @@ package org.jboss.tools.cdi.core.test.tck;
 
 import java.util.Collection;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.cdi.core.IBean;
 import org.jboss.tools.cdi.core.IStereotypeDeclaration;
@@ -28,7 +30,7 @@ public class StereotypeDefinitionTest extends TCKTest {
 	 * 
 	 * @throws JavaModelException
 	 */
-	public void testStereotypeWithScopeType() throws JavaModelException {
+	public void testStereotypeWithScopeType() throws CoreException {
 		Collection<IBean> beans = getBeans("org.jboss.jsr299.tck.tests.definition.stereotype.Moose");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -39,7 +41,8 @@ public class StereotypeDefinitionTest extends TCKTest {
 				.getStereotypeDeclarations();
 		assertEquals("Wrong number of stereotype declarations", 1, declarations
 				.size());
-		assertLocationEquals(declarations, 835, 17);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@AnimalStereotype", 0/*835*/, 17);
 	}
 
 	/**
@@ -72,7 +75,7 @@ public class StereotypeDefinitionTest extends TCKTest {
 	 * section 2.7.2 e)
 	 * section 2.7 d)
 	 */
-	public void testMultipleStereotypesAllowed() {
+	public void testMultipleStereotypesAllowed() throws CoreException {
 		Collection<IBean> beans = cdiProject.getBeans(true, "org.jboss.jsr299.tck.tests.definition.stereotype.HighlandCow", "org.jboss.jsr299.tck.tests.definition.stereotype.Tame");
 		assertEquals("Wrong number of beans.", 1, beans.size());
 		IBean bean = beans.iterator().next();
@@ -83,12 +86,13 @@ public class StereotypeDefinitionTest extends TCKTest {
 						.getSourceType().getFullyQualifiedName());
 		Collection<? extends ITextSourceReference> declarations = bean.getQualifierDeclarations(false);
 		assertEquals("Wrong number of qualifier declarations", 1, declarations.size());
-		assertLocationEquals(declarations, 877, 5);
+		IFile file = (IFile)bean.getResource();
+		assertLocationEquals(file, declarations, "@Tame", 0/*877*/, 5);
 
 		declarations = bean.getStereotypeDeclarations();
 		assertEquals("Wrong number of stereotype declarations", 2, declarations.size());
-		assertLocationEquals(declarations, 835, 23);
-		assertLocationEquals(declarations, 859, 17);
+		assertLocationEquals(file, declarations, "@HornedMammalStereotype", 0/*835*/, 23);
+		assertLocationEquals(file, declarations, "@AnimalStereotype", 0/*859*/, 17);
 	}
 
 	/**

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/TCKTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/TCKTest.java
@@ -49,6 +49,7 @@ import org.jboss.tools.common.java.IParametedType;
 import org.jboss.tools.common.java.impl.JavaAnnotation;
 import org.jboss.tools.common.model.util.EclipseJavaUtil;
 import org.jboss.tools.common.text.ITextSourceReference;
+import org.jboss.tools.common.util.FileUtil;
 import org.jboss.tools.test.util.ResourcesUtils;
 import org.osgi.framework.Bundle;
 
@@ -228,10 +229,15 @@ public class TCKTest extends TestCase {
 		assertEquals("There should be the only bean with " + typeName + " type", 1, beans.size());
 	}
 
-	public static void assertLocationEquals(Collection<? extends ITextSourceReference> references, int startPosition, int length) {
+	public static void assertLocationEquals(IFile file, Collection<? extends ITextSourceReference> references, String wrappingText, int startPosition, int length) throws CoreException {
+		assertNotNull(wrappingText);
+		int correctedStart = startPosition;
+		String c = FileUtil.readStream(file);
+		int i = c.indexOf(wrappingText);
+		if(i >= 0) correctedStart += i;
 		for (ITextSourceReference reference : references) {
-			if(reference.getStartPosition()==startPosition) {
-				assertLocationEquals(reference, startPosition, length);
+			if(reference.getStartPosition()==correctedStart) {
+				assertLocationEquals(file, wrappingText, reference, startPosition, length);
 				return;
 			}
 		}
@@ -472,7 +478,11 @@ public class TCKTest extends TestCase {
 		}
 	}
 
-	public static void assertLocationEquals(ITextSourceReference reference, int startPosition, int length) {
+	public static void assertLocationEquals(IFile file, String wrappingText, ITextSourceReference reference, int startPosition, int length) throws CoreException {
+		assertNotNull(wrappingText);
+		String c = FileUtil.readStream(file);
+		int i = c.indexOf(wrappingText);
+		if(i >= 0) startPosition += i;
 		assertEquals("Wrong start position", startPosition, reference.getStartPosition());
 		assertEquals("Wrong length", length, reference.getLength());
 	}


### PR DESCRIPTION
Excluded exact offsets in asserts, because different line ends
for different OS.
