### PR TITLE
JBIDE-17675 Validation error for subclasses of DeltaSpike JsfModuleConfig class

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
@@ -95,6 +95,7 @@ import org.jboss.tools.cdi.core.extension.feature.IValidatorFeature;
 import org.jboss.tools.cdi.core.preferences.CDIPreferences;
 import org.jboss.tools.cdi.internal.core.impl.CDIProject;
 import org.jboss.tools.cdi.internal.core.impl.CDIProjectAsYouType;
+import org.jboss.tools.cdi.internal.core.impl.ClassBean;
 import org.jboss.tools.cdi.internal.core.impl.SessionBean;
 import org.jboss.tools.cdi.internal.core.impl.definition.Dependencies;
 import org.jboss.tools.common.EclipseUtil;
@@ -2167,7 +2168,6 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 		IAnnotationDeclaration specializesDeclaration = bean.getSpecializesAnnotationDeclaration();
 		if (specializesDeclaration != null) {
 			saveAllSuperTypesAsLinkedResources(bean);
-			try {
 				IBean sBean = bean.getSpecializedBean();
 				if (sBean != null) {
 					if (sBean instanceof ISessionBean || sBean.getAnnotation(CDIConstants.STATELESS_ANNOTATION_TYPE_NAME) != null
@@ -2177,18 +2177,7 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 								specializesDeclaration, bean.getResource());
 					} else {
 						// Validate the specializing bean extends a non simple bean
-						boolean hasDefaultConstructor = true;
-						IMethod[] methods = sBean.getBeanClass().getMethods();
-						for (IMethod method : methods) {
-							if (method.isConstructor()) {
-								if (Flags.isPublic(method.getFlags()) && method.getParameterNames().length == 0) {
-									hasDefaultConstructor = true;
-									break;
-								}
-								hasDefaultConstructor = false;
-							}
-						}
-						if (!hasDefaultConstructor) {
+						if (sBean instanceof ClassBean && !((ClassBean)sBean).getDefinition().hasBeanConstructor()) {
 							addProblem(CDIValidationMessages.ILLEGAL_SPECIALIZING_MANAGED_BEAN, CDIPreferences.ILLEGAL_SPECIALIZING_BEAN,	specializesDeclaration, bean.getResource());
 						}
 					}
@@ -2196,9 +2185,6 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 					// The specializing bean extends nothing
 					addProblem(CDIValidationMessages.ILLEGAL_SPECIALIZING_MANAGED_BEAN, CDIPreferences.ILLEGAL_SPECIALIZING_BEAN, specializesDeclaration, bean.getResource());
 				}
-			} catch (JavaModelException e) {
-				CDICorePlugin.getDefault().logError(e);
-			}
 		}
 
 		try {

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Bird.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Bird.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jsr299.tck.tests.inheritance.specialization.simple;
+
+/**
+ * 
+ * Class that can be specialized, because managed bean may have protected constructor
+ * without parameters.
+ *
+ */
+class Bird
+{
+   protected Bird()
+   {
+      
+   }
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Chicken.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Chicken.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jsr299.tck.tests.inheritance.specialization.simple.broken.noextend3;
+
+import javax.enterprise.inject.Specializes;
+
+/**
+ * 
+ * This is a valid specializing bean because super class is a CDI managed bean.
+ *
+ */
+@Specializes
+class Chicken extends Bird
+{
+   public Chicken()
+   {
+      super();
+   }
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Bird.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Bird.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jsr299.tck.tests.inheritance.specialization.simple;
+
+/**
+ * 
+ * Class that can be specialized, because managed bean may have protected constructor
+ * without parameters.
+ *
+ */
+class Bird
+{
+   protected Bird()
+   {
+      
+   }
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Chicken.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Chicken.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jsr299.tck.tests.inheritance.specialization.simple.broken.noextend3;
+
+import javax.enterprise.inject.Specializes;
+
+/**
+ * 
+ * This is a valid specializing bean because super class is a CDI managed bean.
+ *
+ */
+@Specializes
+class Chicken extends Bird
+{
+   public Chicken()
+   {
+      super();
+   }
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/DefenitionErrorsValidationTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/DefenitionErrorsValidationTest.java
@@ -215,8 +215,13 @@ public class DefenitionErrorsValidationTest extends ValidationTest {
 	 * @throws Exception
 	 */
 	public void testSpecializingClassExtendsNonSimpleBean() throws Exception {
+		//Case of inheriting from a class that has no bean constructor is an illegal specialization.
 		IFile file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/broken/noextend3/Cow_Broken.java");
 		getAnnotationTest().assertAnnotationIsCreated(file, CDIValidationMessages.ILLEGAL_SPECIALIZING_MANAGED_BEAN, 21);
+
+		// Case of inheriting from a class with protected bean constructor is a legal specialization.
+		file = tckProject.getFile("JavaSource/org/jboss/jsr299/tck/tests/inheritance/specialization/simple/Chicken.java");
+		getAnnotationTest().assertAnnotationIsNotCreated(file, CDIValidationMessages.ILLEGAL_SPECIALIZING_MANAGED_BEAN, 26);
 	}
 
 	/**


### PR DESCRIPTION
Validation of specializing bean is fixed. Check for a public constructor
with no parameters in superclass is replaced with a check that superclass
is a managed bean.
