### PR TITLE
Depend on plugin org.jboss.tools.hibernate.temp that temporaryly contains the *Proxy classes

### DIFF
--- a/seam/plugins/org.jboss.tools.seam.ui/META-INF/MANIFEST.MF
+++ b/seam/plugins/org.jboss.tools.seam.ui/META-INF/MANIFEST.MF
@@ -44,7 +44,8 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.7.0",
  org.hibernate.eclipse.libs;bundle-version="3.4.0",
  org.jboss.tools.common.validation,
  org.eclipse.jdt.core.manipulation;bundle-version="1.4.0",
- org.jboss.tools.hibernate.spi;bundle-version="3.8.0"
+ org.jboss.tools.hibernate.spi;bundle-version="3.8.0",
+ org.jboss.tools.hibernate.temp;bundle-version="3.8.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.seam.ui,
  org.jboss.tools.seam.ui.actions,


### PR DESCRIPTION
SettingsProxy has moved to org.jboss.tools.hibernate.temp
