### PR TITLE
JBIDE-18491 JBTValidationException while moving CDI beans into another package

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/impl/CDIProject.java
@@ -653,12 +653,15 @@ public class CDIProject extends CDIElement implements ICDIProject, Cloneable {
 
 	private static String getAnnotationDeclarationKey(IAnnotationDeclaration d, Collection<IMethod> ignoredMembers) throws CoreException {
 		Collection<IMethod> nb = ignoredMembers == null ? new ArrayList<IMethod>() : ignoredMembers;
-		IType type = d.getType();
 		StringBuffer result = new StringBuffer();
 		result.append(d.getTypeName());
 		if(CDIConstants.NAMED_QUALIFIER_TYPE_NAME.equals(d.getTypeName())) {
 			//Declared name is excluded from comparison; names should be compared by invoking getName() method.
 			return result.toString();
+		}
+		IType type = d.getType();
+		if(type == null) {
+			return "";
 		}
 		IMethod[] ms = type.getMethods();
 		if(ms.length > 0) {

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Bear.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Bear.java
@@ -1,0 +1,9 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@Hibernation
+public class Bear {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Den.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Den.java
@@ -1,0 +1,12 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Den {
+
+	@Inject
+	@Hibernation
+	private Bear bear;
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Hibernation.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Hibernation.java
@@ -1,0 +1,21 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+public @interface Hibernation {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Bear.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Bear.java
@@ -1,0 +1,9 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@Hibernation
+public class Bear {
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Den.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Den.java
@@ -1,0 +1,12 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Den {
+
+	@Inject
+	@Hibernation
+	private Bear bear;
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Hibernation.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/tck1.1/JavaSource/org/jboss/jsr299/tck/tests/jbt/validation/inject/incremental/removingtype/Hibernation.java
@@ -1,0 +1,21 @@
+package org.jboss.jsr299.tck.tests.jbt.validation.inject.incremental.removingtype;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+public @interface Hibernation {
+
+}


### PR DESCRIPTION
IAnnotationDeclaration.getType() may return null. Check is required.
In this issue, previous model state is validated and gets obsolete
when classes are moved. After CDI model rebuild, validation will be
restarted.
