### PR TITLE
JBIDE-18841 Add/Remove CDI support when facet version is changed

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/plugin.xml
+++ b/cdi/plugins/org.jboss.tools.cdi.core/plugin.xml
@@ -376,7 +376,7 @@
    		point="org.eclipse.wst.common.project.facet.core.listeners">
       <listener
             class="org.jboss.tools.cdi.internal.core.project.facet.CDIFacetedProjectListener"
-            eventTypes="PRE_INSTALL">
+            eventTypes="PRE_INSTALL,PRE_VERSION_CHANGE">
       </listener>
    </extension>
 

--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/project/facet/CDIFacetedProjectListener.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/project/facet/CDIFacetedProjectListener.java
@@ -54,7 +54,8 @@ public class CDIFacetedProjectListener implements IFacetedProjectListener  {
 
 	@Override
 	public void handleEvent(IFacetedProjectEvent event) {
-		if(event.getType() == Type.PRE_INSTALL && event instanceof IProjectFacetActionEvent) {
+		if((event.getType() == Type.PRE_INSTALL || event.getType() == Type.PRE_VERSION_CHANGE) 
+				&& event instanceof IProjectFacetActionEvent) {
 			IProject project = event.getProject().getProject();
 			IProjectFacet facet = ((IProjectFacetActionEvent)event).getProjectFacet();
 			IProjectFacetVersion version = ((IProjectFacetActionEvent)event).getProjectFacetVersion();

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDIFacetedProjectListenerTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/CDIFacetedProjectListenerTest.java
@@ -52,6 +52,11 @@ public class CDIFacetedProjectListenerTest extends TestCase {
 		doTestFacet(IModuleConstants.JST_WEB_MODULE, "3.1", true);
 	}
 
+	public void testChangeWeb30ToWeb31() throws Exception {
+		doTestFacet(IModuleConstants.JST_WEB_MODULE, "3.0", false);
+		doTestFacet(IModuleConstants.JST_WEB_MODULE, "3.1", true);
+	}
+
 	public void testEJB31() throws Exception {
 		doTestFacet(IModuleConstants.JST_EJB_MODULE, "3.1", false);
 	}
@@ -70,6 +75,10 @@ public class CDIFacetedProjectListenerTest extends TestCase {
 				: facet.getDefaultVersion();
 		IFacetedProject fp = ProjectFacetsManager.create(project);
 		IFacetedProjectWorkingCopy wc = fp.createWorkingCopy();
+		IProjectFacetVersion oldVersion = wc.getProjectFacetVersion(facet);
+		if(oldVersion != null) {
+			wc.removeProjectFacet(oldVersion);
+		}
 		wc.addProjectFacet(version);
 		wc.commitChanges(new NullProgressMonitor());
 		wc.dispose();


### PR DESCRIPTION
CDI support added on facet version change.
CDI support may not be removed on facet version change since
it can remain on any Java project.