### PR TITLE
JBIDE-18964 Changing bean discovery mode doesn't run validation for existing beans

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
+++ b/cdi/plugins/org.jboss.tools.cdi.core/src/org/jboss/tools/cdi/internal/core/validation/CDICoreValidator.java
@@ -475,6 +475,12 @@ public class CDICoreValidator extends CDIValidationErrorManager implements IJava
 			return OK_STATUS;
 		}
 
+		for (IProject iProject : projectSet.getAllProjects()) {
+			if(notValidatedYet(iProject)) {
+				removeAllMessagesFromResource(iProject);
+			}
+		}
+
 		displaySubtask(CDIValidationMessages10.VALIDATING_PROJECT, new String[] {rootProjectName});
 
 		Set<IFile> filesToValidate = new HashSet<IFile>();

--- a/cdi/tests/org.jboss.tools.cdi.core.test/projects/DiscoveryModeChangeTest/src/beans/Wilderness.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/projects/DiscoveryModeChangeTest/src/beans/Wilderness.java
@@ -1,0 +1,11 @@
+package beans;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Wilderness {
+
+	@Inject IBear bear;
+
+}

--- a/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/DiscoveryModeChangeTest.java
+++ b/cdi/tests/org.jboss.tools.cdi.core.test/src/org/jboss/tools/cdi/core/test/tck/validation/DiscoveryModeChangeTest.java
@@ -151,8 +151,15 @@ public class DiscoveryModeChangeTest extends TestCase {
 		
 			IFile zoo = rootProject.getFile("src/beans/Zoo.java");
 			assertTrue(zoo.exists());
+
+			IFile wilderness = testProject.getFile("src/beans/Wilderness.java");
+			assertTrue(wilderness.exists());
+
 			AbstractResourceMarkerTest.assertMarkerIsNotCreated(zoo, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
 			AbstractResourceMarkerTest.assertMarkerIsNotCreated(zoo, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
+		
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
 		
 			IFile beansxml_all = testProject.getFile("src/META-INF/beans.xml.all");
 			assertTrue(beansxml_all.exists());
@@ -160,6 +167,7 @@ public class DiscoveryModeChangeTest extends TestCase {
 			JobUtils.waitForIdle();
 			TestUtil.validate(beansxml);
 			AbstractResourceMarkerTest.assertMarkerIsCreated(zoo, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsCreated(wilderness, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
 		
 			IFile beansxml_none = testProject.getFile("src/META-INF/beans.xml.none");
 			assertTrue(beansxml_none.exists());
@@ -167,6 +175,8 @@ public class DiscoveryModeChangeTest extends TestCase {
 			JobUtils.waitForIdle();
 			TestUtil.validate(beansxml);
 			AbstractResourceMarkerTest.assertMarkerIsCreated(zoo, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
 		
 			IFile beansxml_original = testProject.getFile("src/META-INF/beans.xml.original");
 			assertTrue(beansxml_original.exists());
@@ -175,6 +185,8 @@ public class DiscoveryModeChangeTest extends TestCase {
 			TestUtil.validate(beansxml);
 			AbstractResourceMarkerTest.assertMarkerIsNotCreated(zoo, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
 			AbstractResourceMarkerTest.assertMarkerIsNotCreated(zoo, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.AMBIGUOUS_INJECTION_POINTS[getVersionIndex()], 9);
+			AbstractResourceMarkerTest.assertMarkerIsNotCreated(wilderness, CDIValidationMessages.UNSATISFIED_INJECTION_POINTS[getVersionIndex()], 9);
 		} finally {
 			ResourcesUtils.setBuildAutomatically(saveAutoBuild);
 		}


### PR DESCRIPTION
Case of annotated -> none is improved.