### PR TITLE
JBIDE-20136 Batch diagram generates references in <next> element

### DIFF
--- a/batch/plugins/org.jboss.tools.batch.ui/src/org/jboss/tools/batch/ui/editor/internal/services/diagram/connection/BatchDiagramConnectionService.java
+++ b/batch/plugins/org.jboss.tools.batch.ui/src/org/jboss/tools/batch/ui/editor/internal/services/diagram/connection/BatchDiagramConnectionService.java
@@ -71,6 +71,13 @@ public class BatchDiagramConnectionService extends StandardConnectionService {
 		if (NEXT_ATTRIBUTE_CONNECTION_ID.equals(connectionType)) {
 			return valid(node1, node2);
 		} else {
+			Element target = node2.getLocalModelElement();
+			if(target instanceof FlowElement) {
+				FlowElement f = (FlowElement)target;
+				if(f.getId() == null || f.getId().content() == null) {
+					return false;
+				}
+			}
 			return super.valid(node1, node2, connectionType);
 		}
 	}
@@ -160,6 +167,7 @@ public class BatchDiagramConnectionService extends StandardConnectionService {
 	 */
 	private void initConnections() {
 		connections = new ArrayList<>();
+		if(diagramPart == null) return;
 
 		FlowElementsContainer currentModelRoot = (FlowElementsContainer) diagramPart.getLocalModelElement();
 		attachListenerForNewNodes(currentModelRoot.getFlowElements());


### PR DESCRIPTION
It makes no sense to target next to a flow element with missing id
(non-empty id is required). Diagram will not allow to draw the
connection unless id attribute is set.