### PR TITLE
JBIDE-20147 Batch Property mapping issue with reference

### DIFF
--- a/batch/itests/org.jboss.tools.batch.core.itest/projects/BatchTestProject/src/batch/MyBatchletNamedWithConstant.java
+++ b/batch/itests/org.jboss.tools.batch.core.itest/projects/BatchTestProject/src/batch/MyBatchletNamedWithConstant.java
@@ -1,11 +1,16 @@
 package batch;
 
 import javax.batch.api.AbstractBatchlet;
+import javax.batch.api.BatchProperty;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 @Named(MyBatchletNamedWithConstant.NAME)
 public class MyBatchletNamedWithConstant extends AbstractBatchlet {
-	public static final String NAME = "batchlet_named_with_constant"; 
+	public static final String NAME = "batchlet_named_with_constant";
+	public static final String PROP_NAME = "property_named_with_constant";
+
+	@Inject @BatchProperty(name=MyBatchletNamedWithConstant.PROP_NAME) String time;
 
 	public MyBatchletNamedWithConstant() {
 		// TODO Auto-generated constructor stub

--- a/batch/itests/org.jboss.tools.batch.core.itest/src/org/jboss/tools/batch/core/itest/BatchModelTest.java
+++ b/batch/itests/org.jboss.tools.batch.core.itest/src/org/jboss/tools/batch/core/itest/BatchModelTest.java
@@ -258,7 +258,11 @@ public class BatchModelTest extends TestCase {
 	}
 
 	public void testBatchletNamedWithConstant() {
-		assertArtifactByNameAndType("batchlet_named_with_constant", BatchArtifactType.BATCHLET);
+		IBatchArtifact b = assertArtifactByNameAndType("batchlet_named_with_constant", BatchArtifactType.BATCHLET);
+		IBatchProperty p = b.getProperty("property_named_with_constant");
+		assertNotNull(p);
+		p = b.getProperty("PROP_NAME");
+		assertNull(p);
 	}
 
 }

--- a/batch/plugins/org.jboss.tools.batch.core/src/org/jboss/tools/batch/internal/core/impl/BatchBuilder.java
+++ b/batch/plugins/org.jboss.tools.batch.core/src/org/jboss/tools/batch/internal/core/impl/BatchBuilder.java
@@ -256,7 +256,7 @@ public class BatchBuilder extends IncrementalProjectBuilder implements IIncremen
 			Set<IType> ts = cs.get(f);
 			for (IType type: ts) {
 				TypeDefinition def = new TypeDefinition();
-				def.setType(type, context, TypeDefinition.FLAG_ALL_MEMBERS);
+				def.setType(type, context, 0);
 				if(def.getArtifactType() != null) {
 					context.addType(f, type.getFullyQualifiedName(), def);
 				}

--- a/batch/plugins/org.jboss.tools.batch.core/src/org/jboss/tools/batch/internal/core/impl/BatchProperty.java
+++ b/batch/plugins/org.jboss.tools.batch.core/src/org/jboss/tools/batch/internal/core/impl/BatchProperty.java
@@ -55,9 +55,9 @@ public class BatchProperty implements IBatchProperty {
 
 	@Override
 	public String getPropertyName() {
-		IAnnotationDeclaration d = getBatchPropertyDeclaration();
+		BatchAnnotationDeclaration d = definition.getBatchPropertyAnnotation();
 		if(d != null) {
-			Object o = d.getMemberValue("name");
+			Object o = d.getMemberValue(BatchConstants.ATTR_NAME, true);
 			if(o != null) {
 				return o.toString();
 			}


### PR DESCRIPTION
Previous contribution fixed @Named with value set with Java constant.
This contribution fixes @BatchProperty with name set with Java constant.
Also, fields without @BatchProperty are excluded from property list.