### PR TITLE
JBIDE-21299 EL Knowledge Base Problem with PrimeFaces functions

### DIFF
--- a/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/JavaSource/demo/utils/ELFunctions.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/JavaSource/demo/utils/ELFunctions.java
@@ -31,4 +31,12 @@ public final class ELFunctions {
     public static int doConvertToInteger(Object value) {
         return Integer.valueOf(value.toString());
     }
+
+    public static int getNumber() {
+    	return 0;
+    }
+
+    public static boolean isAgree() {
+    	return true;
+    }
 }

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/WebContent/WEB-INF/target.taglib.xml
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/WebContent/WEB-INF/target.taglib.xml
@@ -11,6 +11,16 @@
  <function>
   <function-name>convertToInteger</function-name>
   <function-class>demo.utils.ELFunctions</function-class>
-  <function-signature>int doConvertToInteger(java.lang.Object)</function-signature>
+  <function-signature>int doConvertToInteger(   java.lang.Object)</function-signature>
+ </function>
+ <function>
+  <function-name>number</function-name>
+  <function-class>demo.utils.ELFunctions</function-class>
+  <function-signature>int getNumber()</function-signature>
+ </function>
+ <function>
+  <function-name>agree</function-name>
+  <function-class>demo.utils.ELFunctions</function-class>
+  <function-signature>java.lang.Boolean isAgree()</function-signature>
  </function>
 </facelet-taglib>

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/WebContent/templates/outputWeekDays.xhtml
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/projects/testJSFProject/WebContent/templates/outputWeekDays.xhtml
@@ -13,6 +13,10 @@
                           value="#{target:convertToInteger(weekDay)}"/>                              
              <f:param
                           value="#{target:loopModel()}"/>                              
+            <f:param
+                          value="#{target:number()}"/>
+            <f:param
+                          value="#{target:agree()}"/>
         </h:outputFormat>
     </t:dataList>
 </html>

--- a/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/JspElFunctionsTest.java
+++ b/jsf/tests/org.jboss.tools.jsf.ui.test/src/org/jboss/tools/jsf/jsp/ca/test/JspElFunctionsTest.java
@@ -74,7 +74,9 @@ public class JspElFunctionsTest extends ContentAssistantTestCase {
    public void testJspElFunctionsCATestFuncs(){
        final String[] proposals = new String[]{
                "target:convertToInteger()", //$NON-NLS-1$
-               "target:loopModel()" //$NON-NLS-1$
+               "target:loopModel()", //$NON-NLS-1$
+               "target:number()", //$NON-NLS-1$
+               "target:agree()" //$NON-NLS-1$
        };
        
        openEditor(PAGE_NAME);


### PR DESCRIPTION
1. Convertion between primitive types and versions is done when comparing
 return type and parameter types of facelet function declaration and Java method.

2. Treating empty parameter list is fixed.