### PR TITLE
Add missing sources to jsf features

### DIFF
--- a/jsf/test-framework/org.jboss.tools.jsf.reddeer/build.properties
+++ b/jsf/test-framework/org.jboss.tools.jsf.reddeer/build.properties
@@ -1,5 +1,6 @@
 source.. = src/
 output.. = bin/
 src.includes = *
+src.excludes = src
 bin.includes = META-INF/,\
                .


### PR DESCRIPTION
I'd like to discuss this with @nickboldt first. Nick said [1] we broke the build when we added jsf.reddeer plugin to the jsf.test.feature. And pointed me to [2]. But I don't understand why is the pom.xml change needed in this case. None of the existing features contains this configuration in pom.xml. Why has the build not failed previously? And why is it not consistent across all repositories?

How can I verify it locally? Local maven build works fine for me (so as it worked when I tested the jsf.reddeer commit)


[1] https://issues.jboss.org/browse/JBIDE-23674?focusedCommentId=13354195&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13354195

[2] https://wiki.eclipse.org/Minerva#Source