### PR TITLE
jbide-24379: silently clean up projects (fix ResourceException for windows)

### DIFF
--- a/cdi/tests/org.jboss.tools.cdi.deltaspike.core.test/src/org/jboss/tools/cdi/deltaspike/core/test/DeltaspikeCoreTestSetup.java
+++ b/cdi/tests/org.jboss.tools.cdi.deltaspike.core.test/src/org/jboss/tools/cdi/deltaspike/core/test/DeltaspikeCoreTestSetup.java
@@ -53,7 +53,7 @@ public class DeltaspikeCoreTestSetup extends TestSetup {
 	@Override
 	protected void tearDown() throws Exception {
 		boolean saveAutoBuild = ResourcesUtils.setBuildAutomatically(false);
-		project.delete(true, true, null);
+		ResourcesUtils.deleteProject(PROJECT_NAME);
 		rootProject.delete(true, true, null);
 		JobUtils.waitForIdle();
 		ResourcesUtils.setBuildAutomatically(saveAutoBuild);

--- a/cdi/tests/org.jboss.tools.cdi.extension.core.test/src/org/jboss/tools/cdi/extension/core/test/batch/BatchCoreTestSetup.java
+++ b/cdi/tests/org.jboss.tools.cdi.extension.core.test/src/org/jboss/tools/cdi/extension/core/test/batch/BatchCoreTestSetup.java
@@ -45,7 +45,7 @@ public class BatchCoreTestSetup extends TestSetup {
 	@Override
 	protected void tearDown() throws Exception {
 		boolean saveAutoBuild = ResourcesUtils.setBuildAutomatically(false);
-		project.delete(true, true, null);
+		ResourcesUtils.deleteProject(PROJECT_NAME);
 		JobUtils.waitForIdle();
 		ResourcesUtils.setBuildAutomatically(saveAutoBuild);
 	}

--- a/cdi/tests/org.jboss.tools.cdi.extension.core.test/src/org/jboss/tools/cdi/extension/core/test/jms/JMSContextTestSetup.java
+++ b/cdi/tests/org.jboss.tools.cdi.extension.core.test/src/org/jboss/tools/cdi/extension/core/test/jms/JMSContextTestSetup.java
@@ -46,7 +46,7 @@ public class JMSContextTestSetup extends TestSetup {
 	@Override
 	protected void tearDown() throws Exception {
 		boolean saveAutoBuild = ResourcesUtils.setBuildAutomatically(false);
-		project.delete(true, true, null);
+		ResourcesUtils.deleteProject(PROJECT_NAME);
 		JobUtils.waitForIdle();
 		ResourcesUtils.setBuildAutomatically(saveAutoBuild);
 	}


### PR DESCRIPTION
@nickboldt @jeffmaury please, merge it. It's likely that there will be more commits, but i think it's better to make them as separate prs. This one must fix problems for cdi tests on Windows 