### PR TITLE
JBIDE-26663: Page "CDI Facets settings" page is not present in the "C…

### DIFF
--- a/cdi/plugins/org.jboss.tools.cdi.ui/plugin.xml
+++ b/cdi/plugins/org.jboss.tools.cdi.ui/plugin.xml
@@ -387,6 +387,9 @@
       <wizard-pages action="jst.cdi.1.2.install">
          <page class="org.jboss.tools.cdi.ui.wizard.facet.CDIInstallWizardPage"/>
       </wizard-pages>
+      <wizard-pages action="jst.cdi.2.0.install">
+         <page class="org.jboss.tools.cdi.ui.wizard.facet.CDIInstallWizardPage"/>
+      </wizard-pages>
    </extension>
 
    <extension


### PR DESCRIPTION
…DI Web Project" wizard when CDI 2.0 is used

- Add missing plugin.xml file

Signed-off-by: Jeff MAURY <jmaury@redhat.com>